### PR TITLE
Update Execute.c

### DIFF
--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/Execute/Execute.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/Execute/Execute.c
@@ -735,7 +735,7 @@ Routine Description:
     //
     // Black-box test file
     //
-    Status = ExecuteBbTestCase (ExecuteInfo, NULL);
+    Status = ExecuteBbTestCase (ExecuteInfo, IhvInterfaceFilter);
     if (EFI_ERROR (Status)) {
       EFI_SCT_DEBUG ((EFI_SCT_D_ERROR, L"Execute BB test case - %r", Status));
       return Status;


### PR DESCRIPTION
Here Device Path filter is supplied for the UEFISCT. So the user can select a particular device and run desire tests.