### PR TITLE
Build Aarch64 with latest EDK2 

### DIFF
--- a/uefi-sct/HowToBuild/How to build SCT.txt
+++ b/uefi-sct/HowToBuild/How to build SCT.txt
@@ -1,0 +1,15 @@
+================================================================================
+                                 HOW TO BUILD
+================================================================================
+
+Build Instructions for UEFI SCTII AARCH64 (Linux)
+
+Pre-requisite: install required tools. For example, on WSL running Ubuntu:
+$ sudo apt-get install build-essential uuid-dev python3-distutils gcc-aarch64-linux-gnu
+
+   1) mkdir "sct_workspace"
+   2) cd sct_workspace
+   3) git clone https://github.com/tianocore/edk2-test.git
+   4) git clone --recursive https://github.com/tianocore/edk2.git
+   5) ln -s edk2-test/uefi-sct/SctPkg/ SctPkg
+   6) SctPkg/build.sh AARCH64 GCC RELEASE

--- a/uefi-sct/SctPkg/UEFI/IHV_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/IHV_SCT.dsc
@@ -56,25 +56,25 @@
   0|DEFAULT              # The entry: 0|DEFAULT is reserved and always required.
 
 [BuildOptions]
-  MSFT:*_*_IA32_CC_FLAGS    = /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32 /wd4133 /Od
+  MSFT:*_*_IA32_CC_FLAGS    = /D EFI32 /wd4133 /Od
   MSFT:*_*_IA32_ASM_FLAGS   = /DEFI32
-  MSFT:*_*_IA32_VFRPP_FLAGS = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
-  MSFT:*_*_IA32_APP_FLAGS   = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
-  MSFT:*_*_IA32_PP_FLAGS    = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
+  MSFT:*_*_IA32_VFRPP_FLAGS = /D EFI32
+  MSFT:*_*_IA32_APP_FLAGS   = /D EFI32
+  MSFT:*_*_IA32_PP_FLAGS    = /D EFI32
 
-  MSFT:*_*_X64_CC_FLAGS    = /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64 /wd4133 /Od
+  MSFT:*_*_X64_CC_FLAGS    = /D EFIX64 /wd4133 /Od
   MSFT:*_*_X64_ASM_FLAGS   = /DEFIX64
-  MSFT:*_*_X64_VFRPP_FLAGS = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
-  MSFT:*_*_X64_APP_FLAGS   = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
-  MSFT:*_*_X64_PP_FLAGS    = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
+  MSFT:*_*_X64_VFRPP_FLAGS = /D EFIX64
+  MSFT:*_*_X64_APP_FLAGS   = /D EFIX64
+  MSFT:*_*_X64_PP_FLAGS    = /D EFIX64
 
-#  GCC:*_*_IA32_CC_FLAGS     = -D EFI32 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -DEFI_SPECIFICATION_VERSION=0x00020028 -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m32 -mabi=ms -D MDE_CPU_X32
+#  GCC:*_*_IA32_CC_FLAGS     = -D EFI32 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m32 -mabi=ms -D MDE_CPU_X32
    GCC:*_*_IA32_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
 #  GCC:*_*_IA32_VFRPP_FLAGS  = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_APP_FLAGS    = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_PP_FLAGS     = -D EFI32 $(GCC_VER_MACRO)
 
-#  GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -DEFI_SPECIFICATION_VERSION=0x00020028 -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m64 -mcmodel=large -mabi=ms -D MDE_CPU_X64
+#  GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m64 -mcmodel=large -mabi=ms -D MDE_CPU_X64
 
    GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
 #  GCC:*_*_X64_VFRPP_FLAGS  = -D EFIX64 $(GCC_VER_MACRO)

--- a/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
@@ -46,8 +46,8 @@
   BUILD_TARGETS                  = DEBUG|RELEASE
   SKUID_IDENTIFIER               = DEFAULT
   
-  DEFINE GCC_VER_MACRO           = -D EFI_SPECIFICATION_VERSION=0x00020028 -D TIANO_RELEASE_VERSION=0x00080006  
-  DEFINE MSFT_VER_MACRO          = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006  
+  DEFINE GCC_VER_MACRO           =
+  DEFINE MSFT_VER_MACRO          =
 
 
 ################################################################################
@@ -60,25 +60,25 @@
   0|DEFAULT              # The entry: 0|DEFAULT is reserved and always required.
 
 [BuildOptions]
-  MSFT:*_*_IA32_CC_FLAGS    = /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32 /wd4133 /Od
-  MSFT:*_*_IA32_ASM_FLAGS   = /DEFI32
-  MSFT:*_*_IA32_VFRPP_FLAGS = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
-  MSFT:*_*_IA32_APP_FLAGS   = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
-  MSFT:*_*_IA32_PP_FLAGS    = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
+  MSFT:*_*_IA32_CC_FLAGS    = /D EFI32 /wd4133 /Od
+  MSFT:*_*_IA32_ASM_FLAGS   = /D EFI32
+  MSFT:*_*_IA32_VFRPP_FLAGS = /D EFI32
+  MSFT:*_*_IA32_APP_FLAGS   = /D EFI32
+  MSFT:*_*_IA32_PP_FLAGS    = /D EFI32
 
-  MSFT:*_*_X64_CC_FLAGS    = /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64 /wd4133 /Od
-  MSFT:*_*_X64_ASM_FLAGS   = /DEFIX64
-  MSFT:*_*_X64_VFRPP_FLAGS = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
-  MSFT:*_*_X64_APP_FLAGS   = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
-  MSFT:*_*_X64_PP_FLAGS    = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
+  MSFT:*_*_X64_CC_FLAGS    = /D EFIX64 /wd4133 /Od
+  MSFT:*_*_X64_ASM_FLAGS   = /D EFIX64
+  MSFT:*_*_X64_VFRPP_FLAGS = /D EFIX64
+  MSFT:*_*_X64_APP_FLAGS   = /D EFIX64
+  MSFT:*_*_X64_PP_FLAGS    = /D EFIX64
 
-#  GCC:*_*_IA32_CC_FLAGS     = -D EFI32 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -DEFI_SPECIFICATION_VERSION=0x00020028 -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m32 -mabi=ms -D MDE_CPU_X32
+#  GCC:*_*_IA32_CC_FLAGS     = -D EFI32 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m32 -mabi=ms -D MDE_CPU_X32
   GCC:*_*_IA32_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
 #  GCC:*_*_IA32_VFRPP_FLAGS  = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_APP_FLAGS    = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_PP_FLAGS     = -D EFI32 $(GCC_VER_MACRO)
 
-#  GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -DEFI_SPECIFICATION_VERSION=0x00020028 -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m64 -mcmodel=large -mabi=ms -D MDE_CPU_X64
+#  GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m64 -mcmodel=large -mabi=ms -D MDE_CPU_X64
    GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
 #  GCC:*_*_X64_VFRPP_FLAGS  = -D EFIX64 $(GCC_VER_MACRO)
 #  GCC:*_*_X64_APP_FLAGS    = -D EFIX64 $(GCC_VER_MACRO)

--- a/uefi-sct/SctPkg/build.sh
+++ b/uefi-sct/SctPkg/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #  Copyright 2006 - 2015 Unified EFI, Inc.<BR>
-#  Copyright (c) 2011 - 2019, ARM Ltd. All rights reserved.<BR>
+#  Copyright (c) 2011 - 2020, ARM Ltd. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -13,7 +13,7 @@
 # 
 ##
 
-SctpackageDependencyList=(EdkCompatibilityPkg SctPkg BaseTools)
+SctpackageDependencyList=(SctPkg BaseTools)
 
 function get_build_arch
 {
@@ -55,8 +55,13 @@ function set_cross_compile
 function get_gcc_version
 {
 	gcc_version=$($1 -dumpversion)
+
+    if [ "$gcc_version" -gt "5" ]; then
+        gcc_version="5"
+    fi
+
 	case $gcc_version in
-		4.6*|4.7*|4.8*|4.9*)
+		4.6*|4.7*|4.8*|4.9*|5*)
 			echo GCC$(echo ${gcc_version} | awk -F. '{print $1$2}')
 			;;
 		*)
@@ -122,7 +127,6 @@ do
 done
 
 export EFI_SOURCE=`pwd`
-export EDK_SOURCE=`pwd`/EdkCompatibilityPkg
 
 # check if the last command was successful
 status=$?
@@ -201,14 +205,13 @@ fi
 #
 if [ -z "${WORKSPACE:-}" ]; then
 	echo Initializing workspace
-	# Uses an external BaseTools project
-	# Uses the BaseTools in edk2
-	export EDK_TOOLS_PATH=`pwd`/BaseTools
+	export WORKSPACE=$PWD
+	export PACKAGES_PATH=$WORKSPACE/edk2:$WORKSPACE/SctPkg
 	# We do not pass BuildArmSct.sh arguments to edksetup.sh
 	while (( "$#" )); do
 		shift
 	done
-	source ./edksetup.sh
+	. edk2/edksetup.sh
 else
 	echo Building from: $WORKSPACE
 fi


### PR DESCRIPTION
Update the SctPkg build scripts and HowTo to build for AARCH64
with latest EDK2, without depending on UDK2017.

This series depends on the change in:
https://edk2.groups.io/g/devel/message/60407

Samer El-Haj-Mahmoud (3):
  uefi-sct/SctPkg: Fix build with latest EDK2
  uefi-sct/SctPkg: Add build instructions with latest EDK2
  uefi-sct/SctPkg: Remove obsolete version macros
