### PR TITLE
[PATCH] Check return status on calls to GetTime()

### DIFF
--- a/uefi-sct/HowToBuild/How to build SCT.txt
+++ b/uefi-sct/HowToBuild/How to build SCT.txt
@@ -1,0 +1,15 @@
+================================================================================
+                                 HOW TO BUILD
+================================================================================
+
+Build Instructions for UEFI SCTII AARCH64 (Linux)
+
+Pre-requisite: install required tools. For example, on WSL running Ubuntu:
+$ sudo apt-get install build-essential uuid-dev python3-distutils gcc-aarch64-linux-gnu
+
+   1) mkdir "sct_workspace"
+   2) cd sct_workspace
+   3) git clone https://github.com/tianocore/edk2-test.git
+   4) git clone --recursive https://github.com/tianocore/edk2.git
+   5) ln -s edk2-test/uefi-sct/SctPkg/ SctPkg
+   6) SctPkg/build.sh AARCH64 GCC RELEASE

--- a/uefi-sct/SctPkg/TestCase/RIVL/Protocol/SimpleNetwork/SimpleNetworkENTSTestCase.c
+++ b/uefi-sct/SctPkg/TestCase/RIVL/Protocol/SimpleNetwork/SimpleNetworkENTSTestCase.c
@@ -24,6 +24,8 @@ Abstract:
 
 #include "SimpleNetworkENTSTestCase.h"
 
+static EFI_TIME Epoch = { .Year = 1970, .Month = 1, .Day = 1 };
+
 //
 // SimpleNetwork.Start
 //
@@ -928,7 +930,8 @@ Returns:
   Status          = EFI_SUCCESS;
   tBS->Stall (5000);
 
-  tRT->GetTime (&BeginTime, NULL);
+  if (tRT->GetTime (&BeginTime, NULL) != EFI_SUCCESS)
+    BeginTime = Epoch;
   for (Index = 0; Index < 1;) {
     Status = SimpleNetwork->Transmit (
                               SimpleNetwork,
@@ -964,7 +967,8 @@ Returns:
     }
   }
 
-  tRT->GetTime (&BeginTime, NULL);
+  if (tRT->GetTime (&BeginTime, NULL) != EFI_SUCCESS)
+    BeginTime = Epoch;
 
   for (Index = 1; Index < TransmitPattern1Number;) {
     Status = SimpleNetwork->Transmit (
@@ -1002,7 +1006,8 @@ Returns:
   }
 
 End:
-  tRT->GetTime (&EndTime, NULL);
+  if (tRT->GetTime (&EndTime, NULL) != EFI_SUCCESS)
+    EndTime = Epoch;
 
   *TransmitPattern1Status = Status;
 
@@ -1125,7 +1130,8 @@ Returns:
   Status          = EFI_SUCCESS;
   tBS->Stall (5000);
 
-  tRT->GetTime (&BeginTime, NULL);
+  if (tRT->GetTime (&BeginTime, NULL) != EFI_SUCCESS)
+    BeginTime = Epoch;
   for (Index = 0; Index < 1;) {
     Status = SimpleNetwork->Transmit (
                               SimpleNetwork,
@@ -1161,7 +1167,8 @@ Returns:
     }
   }
 
-  tRT->GetTime (&BeginTime, NULL);
+  if (tRT->GetTime (&BeginTime, NULL) != EFI_SUCCESS)
+    BeginTime = Epoch;
 
   for (Index = 1; Index < TransmitPattern2Number;) {
     Status = SimpleNetwork->Transmit (
@@ -1199,7 +1206,8 @@ Returns:
   }
 
 End:
-  tRT->GetTime (&EndTime, NULL);
+  if (tRT->GetTime (&EndTime, NULL) != EFI_SUCCESS)
+    EndTime = Epoch;
 
   *TransmitPattern1Status = Status;
 
@@ -1326,7 +1334,8 @@ Returns:
     }
   }
 
-  tRT->GetTime (&BeginTime, NULL);
+  if (tRT->GetTime (&BeginTime, NULL) != EFI_SUCCESS)
+    BeginTime = Epoch;
 
   for (Index = 1; Index < ReceivePattern1Number;) {
     *ReceivePattern1BufferSize = BufferSizeOrg;
@@ -1346,7 +1355,8 @@ Returns:
     }
   }
 
-  tRT->GetTime (&EndTime, NULL);
+  if (tRT->GetTime (&EndTime, NULL) != EFI_SUCCESS)
+    EndTime = Epoch;
 
   *ReceivePattern1Status = Status;
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c
@@ -27,6 +27,8 @@ Abstract:
 #include "SctLib.h"
 #include "MiscBootServicesBBTestMain.h"
 
+static EFI_TIME Epoch = { .Year = 1970, .Month = 1, .Day = 1 };
+
 /**
  *  Entrypoint for gtBS->SetWatchdogTimer() Interface Test.
  *  @param This a pointer of EFI_BB_TEST_PROTOCOL.
@@ -821,13 +823,15 @@ BBTestStallInterfaceTest (
     //
     // 4.2.2.1  Stall must succeed.
     //
-    gtRT->GetTime (&StartTime, NULL);
+    if (gtRT->GetTime (&StartTime, NULL) != EFI_SUCCESS)
+      StartTime = Epoch;
     OldTpl = gtBS->RaiseTPL (TplArray[Index]);
     Status = gtBS->Stall (
                      10000000
                      );
     gtBS->RestoreTPL (OldTpl);
-    gtRT->GetTime (&EndTime, NULL);
+    if (gtRT->GetTime (&EndTime, NULL) != EFI_SUCCESS)
+      EndTime = Epoch;
     if (Status == EFI_SUCCESS) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/DriverBinding/BlackBoxTest/DriverBindingBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/DriverBinding/BlackBoxTest/DriverBindingBBTestFunction.c
@@ -36,6 +36,8 @@ static const UINTN  MonthLengths[2][12] = {
   { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
 };
 
+static EFI_TIME Epoch = { .Year = 1970, .Month = 1, .Day = 1 };
+
 #define MINS_PER_HOUR       60
 #define HOURS_PER_DAY       24
 #define SECS_PER_MIN        60
@@ -1052,7 +1054,8 @@ EndLogging (
   WriteLogFile (Private, DashLine, SYSTEMLOG);
   WriteLogFile (Private, DashLine, CASELOG);
 
-  gtRT->GetTime (&CurrentTime, NULL);
+  if (gtRT->GetTime (&CurrentTime, NULL) != EFI_SUCCESS)
+    CurrentTime = Epoch;
   DBSPrint (Buffer, EFI_MAX_PRINT_BUFFER, L"Test Finished: %t\n", &CurrentTime);
 
   WriteLogFile (Private, Buffer, SYSTEMLOG);

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/StandardTest/StandardTest.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/StandardTest/StandardTest.c
@@ -30,6 +30,8 @@ Abstract:
 #include "StandardTest.h"
 #include <Library/EntsLib.h>
 
+static EFI_TIME Epoch = { .Year = 1970, .Month = 1, .Day = 1 };
+
 //
 // Prototypes
 //
@@ -1081,7 +1083,8 @@ Returns:
     StslWriteLogFile (Private, Buffer);
 
     CurrentTime = &Private->StartTime;
-    tRT->GetTime (CurrentTime, NULL);
+    if (tRT->GetTime (CurrentTime, NULL) != EFI_SUCCESS)
+      *CurrentTime = Epoch;
 
   } else {
     StslWriteLogFile (Private, DashLine);
@@ -1118,7 +1121,8 @@ Returns:
 
     StslWriteLogFileName (Private);
     CurrentTime = &Private->StartTime;
-    tRT->GetTime (CurrentTime, NULL);
+    if (tRT->GetTime (CurrentTime, NULL) != EFI_SUCCESS)
+      *CurrentTime = Epoch;
     SctSPrint (Buffer, EFI_MAX_PRINT_BUFFER, L"Test Started: %t\n", CurrentTime);
     StslWriteLogFile (Private, Buffer);
 
@@ -1238,7 +1242,8 @@ Returns:
 
   StslWriteLogFileName (Private);
 
-  tRT->GetTime (&CurrentTime, NULL);
+  if (tRT->GetTime (&CurrentTime, NULL) != EFI_SUCCESS)
+    CurrentTime = Epoch;
 
   SecondsElapsed = SecondsElapsedFromBaseYear (
                      Private->StartTime.Year,

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasDispatcher/Core/Eas.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasDispatcher/Core/Eas.c
@@ -24,7 +24,10 @@ Abstract:
 
 
 #include "Sct.h"
+#include "Sct.h"
 #include EFI_TEST_PROTOCOL_DEFINITION (EntsMonitorProtocol)
+
+static EFI_TIME Epoch = { .Year = 1970, .Month = 1, .Day = 1 };
 
 STATIC
 EFI_STATUS
@@ -310,7 +313,8 @@ DelaySctAgentCmdPost (
   }
   SctAgentCmdDelayedPost->CmdReturn      = CmdReturn;
   SctAgentCmdDelayedPost->Cmd.ComdResult = CmdResult;
-  tRT->GetTime (&SctAgentCmdDelayedPost->StartTime, NULL);
+  if (tRT->GetTime (&SctAgentCmdDelayedPost->StartTime, NULL) != EFI_SUCCESS)
+    SctAgentCmdDelayedPost->StartTime = Epoch;
 
   return Status;
 }
@@ -327,7 +331,8 @@ PostSctAgentDelayedCmd (
     return EFI_SUCCESS;
   }
 
-  tRT->GetTime (&SctAgentCmdDelayedPost->EndTime, NULL);
+  if (tRT->GetTime (&SctAgentCmdDelayedPost->EndTime, NULL) != EFI_SUCCESS)
+    SctAgentCmdDelayedPost->EndTime = Epoch;
 
   Status = RecordMessage (
             &SctAgentCmdDelayedPost->Cmd.ComdRuntimeInfo,

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasDispatcher/Exec/EasCmdDisp.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasDispatcher/Exec/EasCmdDisp.c
@@ -50,6 +50,8 @@ Abstract:
 
 EFI_CPU_ARCH_PROTOCOL *Cpu = NULL;
 
+static EFI_TIME Epoch = { .Year = 1970, .Month = 1, .Day = 1 };
+
 //
 // Local Function Definition
 //
@@ -132,9 +134,11 @@ Returns:
   //
   // Perform EFTP operation.
   //
-  tRT->GetTime (&StartTime, NULL);
+  if (tRT->GetTime (&StartTime, NULL) != EFI_SUCCESS)
+    StartTime = Epoch;
   Status = EftpDispatchFileTransferComd (FileCmdType);
-  tRT->GetTime (&EndTime, NULL);
+  if (tRT->GetTime (&EndTime, NULL) != EFI_SUCCESS)
+    EndTime = Epoch;
 
   if (Status == EFI_OUT_OF_RESOURCES) {
     return EFI_OUT_OF_RESOURCES;
@@ -365,9 +369,11 @@ Returns:
   //
   // Execute Shell Command
   //
-  tRT->GetTime (&StartTime, NULL);
+  if (tRT->GetTime (&StartTime, NULL) != EFI_SUCCESS)
+    StartTime = Epoch;
   Status = SctShellExecute (&mImageHandle, (gEasFT->Cmd)->ComdArg, FALSE, NULL, NULL);;
-  tRT->GetTime (&EndTime, NULL);
+  if (tRT->GetTime (&EndTime, NULL) != EFI_SUCCESS)
+    EndTime = Epoch;
   EFI_ENTS_DEBUG ((EFI_ENTS_D_TRACE, L"dispatch:(%s)", (gEasFT->Cmd)->ComdArg));
   SctPrint (L"dispatch:(%s) - %r\n", (gEasFT->Cmd)->ComdArg, Status);
   if (Status == EFI_OUT_OF_RESOURCES) {
@@ -1483,9 +1489,11 @@ Returns:
   //
   // Resume SCT execution by executing "sct -c" in sct passive mode.
   //
-  tRT->GetTime (&StartTime, NULL);
+  if (tRT->GetTime (&StartTime, NULL) != EFI_SUCCESS)
+    StartTime = Epoch;
   Status = SctShellExecute (&mImageHandle, (gEasFT->Cmd)->ComdArg, FALSE, NULL, NULL);;
-  tRT->GetTime (&EndTime, NULL);
+  if (tRT->GetTime (&EndTime, NULL) != EFI_SUCCESS)
+    EndTime = Epoch;
   EFI_ENTS_DEBUG ((EFI_ENTS_D_TRACE, L"dispatch:(%s)", (gEasFT->Cmd)->ComdArg));
   SctPrint (L"dispatch:(%s) - %r\n", (gEasFT->Cmd)->ComdArg, Status);
   if (Status == EFI_OUT_OF_RESOURCES) {

--- a/uefi-sct/SctPkg/UEFI/IHV_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/IHV_SCT.dsc
@@ -56,25 +56,25 @@
   0|DEFAULT              # The entry: 0|DEFAULT is reserved and always required.
 
 [BuildOptions]
-  MSFT:*_*_IA32_CC_FLAGS    = /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32 /wd4133 /Od
+  MSFT:*_*_IA32_CC_FLAGS    = /D EFI32 /wd4133 /Od
   MSFT:*_*_IA32_ASM_FLAGS   = /DEFI32
-  MSFT:*_*_IA32_VFRPP_FLAGS = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
-  MSFT:*_*_IA32_APP_FLAGS   = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
-  MSFT:*_*_IA32_PP_FLAGS    = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
+  MSFT:*_*_IA32_VFRPP_FLAGS = /D EFI32
+  MSFT:*_*_IA32_APP_FLAGS   = /D EFI32
+  MSFT:*_*_IA32_PP_FLAGS    = /D EFI32
 
-  MSFT:*_*_X64_CC_FLAGS    = /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64 /wd4133 /Od
+  MSFT:*_*_X64_CC_FLAGS    = /D EFIX64 /wd4133 /Od
   MSFT:*_*_X64_ASM_FLAGS   = /DEFIX64
-  MSFT:*_*_X64_VFRPP_FLAGS = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
-  MSFT:*_*_X64_APP_FLAGS   = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
-  MSFT:*_*_X64_PP_FLAGS    = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
+  MSFT:*_*_X64_VFRPP_FLAGS = /D EFIX64
+  MSFT:*_*_X64_APP_FLAGS   = /D EFIX64
+  MSFT:*_*_X64_PP_FLAGS    = /D EFIX64
 
-#  GCC:*_*_IA32_CC_FLAGS     = -D EFI32 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -DEFI_SPECIFICATION_VERSION=0x00020028 -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m32 -mabi=ms -D MDE_CPU_X32
+#  GCC:*_*_IA32_CC_FLAGS     = -D EFI32 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m32 -mabi=ms -D MDE_CPU_X32
    GCC:*_*_IA32_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
 #  GCC:*_*_IA32_VFRPP_FLAGS  = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_APP_FLAGS    = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_PP_FLAGS     = -D EFI32 $(GCC_VER_MACRO)
 
-#  GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -DEFI_SPECIFICATION_VERSION=0x00020028 -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m64 -mcmodel=large -mabi=ms -D MDE_CPU_X64
+#  GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m64 -mcmodel=large -mabi=ms -D MDE_CPU_X64
 
    GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
 #  GCC:*_*_X64_VFRPP_FLAGS  = -D EFIX64 $(GCC_VER_MACRO)

--- a/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
@@ -46,8 +46,8 @@
   BUILD_TARGETS                  = DEBUG|RELEASE
   SKUID_IDENTIFIER               = DEFAULT
   
-  DEFINE GCC_VER_MACRO           = -D EFI_SPECIFICATION_VERSION=0x00020028 -D TIANO_RELEASE_VERSION=0x00080006  
-  DEFINE MSFT_VER_MACRO          = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006  
+  DEFINE GCC_VER_MACRO           =
+  DEFINE MSFT_VER_MACRO          =
 
 
 ################################################################################
@@ -60,25 +60,25 @@
   0|DEFAULT              # The entry: 0|DEFAULT is reserved and always required.
 
 [BuildOptions]
-  MSFT:*_*_IA32_CC_FLAGS    = /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32 /wd4133 /Od
-  MSFT:*_*_IA32_ASM_FLAGS   = /DEFI32
-  MSFT:*_*_IA32_VFRPP_FLAGS = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
-  MSFT:*_*_IA32_APP_FLAGS   = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
-  MSFT:*_*_IA32_PP_FLAGS    = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFI32
+  MSFT:*_*_IA32_CC_FLAGS    = /D EFI32 /wd4133 /Od
+  MSFT:*_*_IA32_ASM_FLAGS   = /D EFI32
+  MSFT:*_*_IA32_VFRPP_FLAGS = /D EFI32
+  MSFT:*_*_IA32_APP_FLAGS   = /D EFI32
+  MSFT:*_*_IA32_PP_FLAGS    = /D EFI32
 
-  MSFT:*_*_X64_CC_FLAGS    = /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64 /wd4133 /Od
-  MSFT:*_*_X64_ASM_FLAGS   = /DEFIX64
-  MSFT:*_*_X64_VFRPP_FLAGS = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
-  MSFT:*_*_X64_APP_FLAGS   = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
-  MSFT:*_*_X64_PP_FLAGS    = /D EFI_SPECIFICATION_VERSION=0x00020028 /D TIANO_RELEASE_VERSION=0x00080006 /D EFIX64
+  MSFT:*_*_X64_CC_FLAGS    = /D EFIX64 /wd4133 /Od
+  MSFT:*_*_X64_ASM_FLAGS   = /D EFIX64
+  MSFT:*_*_X64_VFRPP_FLAGS = /D EFIX64
+  MSFT:*_*_X64_APP_FLAGS   = /D EFIX64
+  MSFT:*_*_X64_PP_FLAGS    = /D EFIX64
 
-#  GCC:*_*_IA32_CC_FLAGS     = -D EFI32 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -DEFI_SPECIFICATION_VERSION=0x00020028 -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m32 -mabi=ms -D MDE_CPU_X32
+#  GCC:*_*_IA32_CC_FLAGS     = -D EFI32 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m32 -mabi=ms -D MDE_CPU_X32
   GCC:*_*_IA32_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
 #  GCC:*_*_IA32_VFRPP_FLAGS  = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_APP_FLAGS    = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_PP_FLAGS     = -D EFI32 $(GCC_VER_MACRO)
 
-#  GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -DEFI_SPECIFICATION_VERSION=0x00020028 -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m64 -mcmodel=large -mabi=ms -D MDE_CPU_X64
+#  GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m64 -mcmodel=large -mabi=ms -D MDE_CPU_X64
    GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
 #  GCC:*_*_X64_VFRPP_FLAGS  = -D EFIX64 $(GCC_VER_MACRO)
 #  GCC:*_*_X64_APP_FLAGS    = -D EFIX64 $(GCC_VER_MACRO)

--- a/uefi-sct/SctPkg/build.sh
+++ b/uefi-sct/SctPkg/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 #  Copyright 2006 - 2015 Unified EFI, Inc.<BR>
-#  Copyright (c) 2011 - 2019, ARM Ltd. All rights reserved.<BR>
+#  Copyright (c) 2011 - 2020, ARM Ltd. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -13,7 +13,7 @@
 # 
 ##
 
-SctpackageDependencyList=(EdkCompatibilityPkg SctPkg BaseTools)
+SctpackageDependencyList=(SctPkg BaseTools)
 
 function get_build_arch
 {
@@ -55,8 +55,13 @@ function set_cross_compile
 function get_gcc_version
 {
 	gcc_version=$($1 -dumpversion)
+
+    if [ "$gcc_version" -gt "5" ]; then
+        gcc_version="5"
+    fi
+
 	case $gcc_version in
-		4.6*|4.7*|4.8*|4.9*)
+		4.6*|4.7*|4.8*|4.9*|5*)
 			echo GCC$(echo ${gcc_version} | awk -F. '{print $1$2}')
 			;;
 		*)
@@ -122,7 +127,6 @@ do
 done
 
 export EFI_SOURCE=`pwd`
-export EDK_SOURCE=`pwd`/EdkCompatibilityPkg
 
 # check if the last command was successful
 status=$?
@@ -201,14 +205,13 @@ fi
 #
 if [ -z "${WORKSPACE:-}" ]; then
 	echo Initializing workspace
-	# Uses an external BaseTools project
-	# Uses the BaseTools in edk2
-	export EDK_TOOLS_PATH=`pwd`/BaseTools
+	export WORKSPACE=$PWD
+	export PACKAGES_PATH=$WORKSPACE/edk2:$WORKSPACE/SctPkg
 	# We do not pass BuildArmSct.sh arguments to edksetup.sh
 	while (( "$#" )); do
 		shift
 	done
-	source ./edksetup.sh
+	. edk2/edksetup.sh
 else
 	echo Building from: $WORKSPACE
 fi


### PR DESCRIPTION
Not all platforms implement GetTime(), but the SCT just assumes calls to
GetTime will be successful. If GetTime() doesn't return EFI_SUCCESS,
then the EFI_TIME value will be uninitialized data.

Fix by checking the GetTime() return code. If it doesn't return
EFI_SUCCESS, then use the traditional 1/1/1970 epoch so that the test
report at least looks sane, but it is obvious that we don't have a valid
timestamp.

https://edk2.groups.io/g/devel/message/63588
