### PR TITLE
uefi-sct/SctPkg: fix variable services conformance test

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/VariableServices/BlackBoxTest/AuthVariableServicesBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/VariableServices/BlackBoxTest/AuthVariableServicesBBTestConformance.c
@@ -287,7 +287,7 @@ AuthVariableDERConfTest (
                    &MaximumVariableSize
                    );
 
-    if (Status == EFI_UNSUPPORTED) {
+    if (Status == EFI_SUCCESS || Status == EFI_UNSUPPORTED) {
       Result = EFI_TEST_ASSERTION_PASSED;
     } else {
       Result = EFI_TEST_ASSERTION_FAILED;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2865

QueryVariableInfo() returning EFI_SUCCESS for a legal combination of attributes is not an error.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>