### PR TITLE
uefi-sct/SctPkg: EFI_RNG_PROTOCOL.GetInfo check size != 0

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RandomNumber/BlackBoxTest/RandomNumberBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RandomNumber/BlackBoxTest/RandomNumberBBTestConformance.c
@@ -169,7 +169,8 @@ BBTestGetInfoConformanceTestCheckpoint1 (
     return Status;
   }
 
-  if (EFI_BUFFER_TOO_SMALL == Status && RNGAlgorithmListSize % sizeof(EFI_RNG_ALGORITHM) == 0) {
+  if (EFI_BUFFER_TOO_SMALL == Status && RNGAlgorithmListSize &&
+      RNGAlgorithmListSize % sizeof(EFI_RNG_ALGORITHM) == 0) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2438

The EFI_RNG_PROTOCOL conformance test checks that the size returned by
GetInfo() is a multiple of 16. This would be fulfilled by size == 0.

The UEFI specification requires that at least one algorithm is implemented.
So we should check that size is non-zero too.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>