### PR TITLE
uefi-sct/SctPkg: Changed gcc version to be integer

### DIFF
--- a/uefi-sct/SctPkg/build.sh
+++ b/uefi-sct/SctPkg/build.sh
@@ -56,8 +56,8 @@ function get_gcc_version
 {
 	gcc_version=$($1 -dumpversion)
 
-    if [ "$gcc_version" -gt "5" ]; then
-        gcc_version="5"
+    if [ ${gcc_version%%.*} -gt 5 ]; then
+        gcc_version=5
     fi
 
 	case $gcc_version in


### PR DESCRIPTION
gcc_version returned by compiler is a string, and needs to be converted to a integer before testing

Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Eric Jin <eric.jin@intel.com>
Cc: Irene Park <ipark@nvidia.com>
Cc: Heinrich Schuchardt <xypron.glpk@gmx.de>
Cc: Samer El-Haj-Mahmoud <samer.el-haj-mahmoud@arm.com>
Signed-off-by: Joseph Hemann <joseph.hemann@arm.com>
Change-Id: I24f3f52c12660928b58e6f836fdef86890688d26

Reviewed-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>