### PR TITLE
SctPkg: Updated Start Address Alignment code

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MemoryAllocationServices/BlackBoxTest/MemoryAllocationServicesBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MemoryAllocationServices/BlackBoxTest/MemoryAllocationServicesBBTestFunction.c
@@ -354,7 +354,6 @@ BBTestAllocatePagesInterfaceTest (
   EFI_TPL                              OldTpl;
   EFI_MEMORY_DESCRIPTOR                Descriptor;
   UINTN                                PageNum;
-  UINTN                                Alignment;
 
   //
   // Get the Standard Library Interface
@@ -701,23 +700,14 @@ BBTestAllocatePagesInterfaceTest (
         PageNum = (UINTN)Descriptor.NumberOfPages;
         Start   = Descriptor.PhysicalStart;
 
-        Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-
-        if  (AllocatePagesMemoryType[TypeIndex] == EfiACPIReclaimMemory   ||
-             AllocatePagesMemoryType[TypeIndex] == EfiACPIMemoryNVS       ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesCode ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesData) {
-
-          Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-        }
-
-        Start   = (Start + Alignment - 1) & ~(Alignment - 1);
-        PageNum -= EFI_SIZE_TO_PAGES (Start - Descriptor.PhysicalStart);
-
-        PageNum &= ~(EFI_SIZE_TO_PAGES (Alignment) - 1);
-        if (PageNum <= EFI_SIZE_TO_PAGES (Alignment)) {
+        //
+        // Some memory types need more alignment than 4K, so
+        //
+        if (PageNum <= 0x10) {
           break;
         }
+        Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
+        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
 
         Memory  = Start;
 
@@ -840,23 +830,14 @@ BBTestAllocatePagesInterfaceTest (
         PageNum = (UINTN)Descriptor.NumberOfPages;
         Start   = Descriptor.PhysicalStart;
 
-        Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-
-        if  (AllocatePagesMemoryType[TypeIndex] == EfiACPIReclaimMemory   ||
-             AllocatePagesMemoryType[TypeIndex] == EfiACPIMemoryNVS       ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesCode ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesData) {
-
-          Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-        }
-
-        Start   = (Start + Alignment - 1) & ~(Alignment - 1);
-        PageNum -= EFI_SIZE_TO_PAGES (Start - Descriptor.PhysicalStart);
-
-        PageNum &= ~(EFI_SIZE_TO_PAGES (Alignment) - 1);
-        if (PageNum <= EFI_SIZE_TO_PAGES (Alignment)) {
+        //
+        // Some memory types need more alignment than 4K, so
+        //
+        if (PageNum <= 0x10) {
           break;
         }
+        Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
+        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
 
         Memory  = Start;
 
@@ -972,23 +953,14 @@ BBTestAllocatePagesInterfaceTest (
         PageNum = (UINTN)Descriptor.NumberOfPages;
         Start   = Descriptor.PhysicalStart;
 
-        Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-
-        if  (AllocatePagesMemoryType[TypeIndex] == EfiACPIReclaimMemory   ||
-             AllocatePagesMemoryType[TypeIndex] == EfiACPIMemoryNVS       ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesCode ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesData) {
-
-          Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-        }
-
-        Start   = (Start + Alignment - 1) & ~(Alignment - 1);
-        PageNum -= EFI_SIZE_TO_PAGES (Start - Descriptor.PhysicalStart);
-
-        PageNum &= ~(EFI_SIZE_TO_PAGES (Alignment) - 1);
-        if (PageNum <= EFI_SIZE_TO_PAGES (Alignment)) {
+        //
+        // Some memory types need more alignment than 4K, so
+        //
+        if (PageNum <= 0x10) {
           break;
         }
+        Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
+        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
 
         Memory = Start + (SctLShiftU64 (PageNum/3, EFI_PAGE_SHIFT) & 0xFFFFFFFFFFFF0000);
 
@@ -1104,23 +1076,14 @@ BBTestAllocatePagesInterfaceTest (
         PageNum = (UINTN)Descriptor.NumberOfPages;
         Start   = Descriptor.PhysicalStart;
 
-        Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-
-        if  (AllocatePagesMemoryType[TypeIndex] == EfiACPIReclaimMemory   ||
-             AllocatePagesMemoryType[TypeIndex] == EfiACPIMemoryNVS       ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesCode ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesData) {
-
-          Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-        }
-
-        Start   = (Start + Alignment - 1) & ~(Alignment - 1);
-        PageNum -= EFI_SIZE_TO_PAGES (Start - Descriptor.PhysicalStart);
-
-        PageNum &= ~(EFI_SIZE_TO_PAGES (Alignment) - 1);
-        if (PageNum <= EFI_SIZE_TO_PAGES (Alignment)) {
+        //
+        // Some memory types need more alignment than 4K, so
+        //
+        if (PageNum <= 0x10) {
           break;
         }
+        Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
+        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
 
         Memory  = Start + (SctLShiftU64 (PageNum * 2 / 3, EFI_PAGE_SHIFT) & 0xFFFFFFFFFFFF0000);
 
@@ -1243,23 +1206,14 @@ BBTestAllocatePagesInterfaceTest (
         PageNum = (UINTN)Descriptor.NumberOfPages;
         Start   = Descriptor.PhysicalStart;
 
-        Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-
-        if  (AllocatePagesMemoryType[TypeIndex] == EfiACPIReclaimMemory   ||
-             AllocatePagesMemoryType[TypeIndex] == EfiACPIMemoryNVS       ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesCode ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesData) {
-
-          Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-        }
-
-        Start   = (Start + Alignment - 1) & ~(Alignment - 1);
-        PageNum -= EFI_SIZE_TO_PAGES (Start - Descriptor.PhysicalStart);
-
-        PageNum &= ~(EFI_SIZE_TO_PAGES (Alignment) - 1);
-        if (PageNum <= EFI_SIZE_TO_PAGES (Alignment)) {
+        //
+        // Some memory types need more alignment than 4K, so
+        //
+        if (PageNum <= 0x10) {
           break;
         }
+        Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
+        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
 
         Memory  = Start;
 
@@ -1375,23 +1329,14 @@ BBTestAllocatePagesInterfaceTest (
         PageNum = (UINTN)Descriptor.NumberOfPages;
         Start   = Descriptor.PhysicalStart;
 
-        Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-
-        if  (AllocatePagesMemoryType[TypeIndex] == EfiACPIReclaimMemory   ||
-             AllocatePagesMemoryType[TypeIndex] == EfiACPIMemoryNVS       ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesCode ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesData) {
-
-          Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-        }
-
-        Start   = (Start + Alignment - 1) & ~(Alignment - 1);
-        PageNum -= EFI_SIZE_TO_PAGES (Start - Descriptor.PhysicalStart);
-
-        PageNum &= ~(EFI_SIZE_TO_PAGES (Alignment) - 1);
-        if (PageNum <= EFI_SIZE_TO_PAGES (Alignment)) {
+        //
+        // Some memory types need more alignment than 4K, so
+        //
+        if (PageNum <= 0x10) {
           break;
         }
+        Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
+        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
 
         Memory  = Start;
 
@@ -1523,23 +1468,14 @@ BBTestAllocatePagesInterfaceTest (
         PageNum = (UINTN)Descriptor.NumberOfPages;
         Start   = Descriptor.PhysicalStart;
 
-        Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
-
-        if  (AllocatePagesMemoryType[TypeIndex] == EfiACPIReclaimMemory   ||
-             AllocatePagesMemoryType[TypeIndex] == EfiACPIMemoryNVS       ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesCode ||
-             AllocatePagesMemoryType[TypeIndex] == EfiRuntimeServicesData) {
-
-          Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
-        }
-
-        Start   = (Start + Alignment - 1) & ~(Alignment - 1);
-        PageNum -= EFI_SIZE_TO_PAGES (Start - Descriptor.PhysicalStart);
-
-        PageNum &= ~(EFI_SIZE_TO_PAGES (Alignment) - 1);
-        if (PageNum <= EFI_SIZE_TO_PAGES (Alignment)) {
+        //
+        // Some memory types need more alignment than 4K, so
+        //
+        if (PageNum <= 0x10) {
           break;
         }
+        Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
+        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
 
         Memory  = Start;
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=2671

AllocatePages Functionality test.
Existing Code Increase Start address by 64k, even if Start is already aligned to 64k.

Suggested Change will not modify Start,
if Start is already aligned to 64k

For Eg.
Available Memory(Start is aligned to 64k):
Start      End      PageNum(Free Pages)
80000000  EBD6EFFF  6BD6F(Number of Free pages are not 64k Aligned)

edk2-test code:
Start is increased & aligned by 64k(Equal to 16 pages of size 4k each).
Request for Pagenum is minus by 16 Pages.
Start = (Start + 0x10000) & 0xFFFFFFFFFFFF0000 Start = (0x80000000 + 0x10000) & 0xFFFFFFFFFFFF0000 = 0x80010000 PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000) = 0x6BD6F - 0x10 = 0x6BD5F

edk2 memory allocation code to Align the requested pages to 64k boundary:
------------------------------------------------------------------------
NumberOfPages += EFI_SIZE_TO_PAGES(Alignment) - 1 = 0x6BD5F + 0xF = 0x6BD6E NumberOfPages &= ~(EFI_SIZE_TO_PAGES(Alignment) - 1) = 0x6BD6E & 0xFFFFFFF0
                                                     = 0x6BD60

We can observe that requested pages is incraesed by 1 page, which results in below error.
ConvertPages: range 80010000 - EBD6FFFF covers multiple entries.

Signed-off-by: Gaurav Jain <gaurav.jain@nxp.com>
Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>

Maintainer's Note: Rolling back the solution
https://edk2.groups.io/g/devel/message/62055
as it it failed in some implementations.

Adding the solution as in the below message:
https://edk2.groups.io/g/devel/message/58531