### PR TITLE
uefi-sct:Add maintainer in Maintainers.txt

### DIFF
--- a/uefi-sct/Maintainers.txt
+++ b/uefi-sct/Maintainers.txt
@@ -41,6 +41,7 @@ UEFI-SCT:
 
 M: Eric Jin <eric.jin@intel.com>
 M: G Edhaya Chandran <Edhaya.Chandran@arm.com>
+M: Barton Gao <gaojie@byosoft.com.cn>
 
 R: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
 


### PR DESCRIPTION
Request to add Barton Gao from Byosoft as maintainer of uefi-sct.

Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Eric Jin <eric.jin@intel.com>
Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Signed-off-by: Barton Gao <gaojie@byosoft.com.cn>

Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>