### PR TITLE
Fix missing symbols on edk2-test build

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/ConfigKeywordHandler/BlackBoxTest/Dependency/SampleDriver/DriverSample.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/ConfigKeywordHandler/BlackBoxTest/Dependency/SampleDriver/DriverSample.c
@@ -920,8 +920,9 @@ ExtractConfig (
 
       BackupChar = Value[ValueStrLen];
       *Value++   = L'=';
-      Value += UnicodeValueToString (
+      Value += UnicodeValueToStringS (
                  Value, 
+                 BufferSize - (Value - *Results),
                  PREFIX_ZERO | RADIX_HEX, 
                  PrivateData->Configuration.NameValueVar0, 
                  sizeof (PrivateData->Configuration.NameValueVar0) * 2
@@ -939,8 +940,9 @@ ExtractConfig (
 
       BackupChar = Value[ValueStrLen];
       *Value++   = L'=';
-      Value += UnicodeValueToString (
+      Value += UnicodeValueToStringS (
                 Value, 
+                BufferSize - (Value - *Results),
                 PREFIX_ZERO | RADIX_HEX, 
                 PrivateData->Configuration.NameValueVar1, 
                 sizeof (PrivateData->Configuration.NameValueVar1) * 2
@@ -962,7 +964,8 @@ ExtractConfig (
       //
       StrPointer = (CHAR16 *) PrivateData->Configuration.NameValueVar2;
       for (; *StrPointer != L'\0'; StrPointer++) {
-        Value += UnicodeValueToString (Value, PREFIX_ZERO | RADIX_HEX, *StrPointer, 4);
+        Value += UnicodeValueToStringS (Value, BufferSize - (Value - *Results),
+                                        PREFIX_ZERO | RADIX_HEX, *StrPointer, 4);
       }
     }
     
@@ -1894,7 +1897,7 @@ DriverSampleInit (
   MY_EFI_VARSTORE_DATA            *VarStoreConfig;
   EFI_INPUT_KEY                   HotKey;
   EDKII_FORM_BROWSER_EXTENSION_PROTOCOL *FormBrowserEx;
-#if 1
+#if 0
     EFI_STRING                      Progress;
   EFI_STRING                      Results;
   UINT32                          ProgressErr;
@@ -2243,7 +2246,9 @@ DriverSampleInit (
     HiiRemovePackages (HiiHandle[1]);
   }
 
-#if 1
+#if 0 // gcl - This test case is incomplete and fails to compile. StrnCpy needs to be
+      // changed to StrnCpyS() to fix build error, but there is a larger problem that
+      // the testcases don't match the spec or test any behaviour
   //
   // Test Cases 1: Keyword - GetData and change the value by SetData
   //


### PR DESCRIPTION
EDK2 has removed some deprecated function wrappers. The BlackBoxTest
still uses StrnCpy() and UnicodeValueToString(). This patch fixes the
build by moving to UnicodeValueToStringS(). However, the code using
StrnCpy() is simply #ifdef'd out because on reading the code it is
apparent that the testcase is non-functional and the fix is not
straightforward. As I understand it, there are no functional
implementations of the interface in the wild anyway. If/when it does
become important someone can do the work of making a proper test case.

Fixes: Bug 2068

Signed-off-by: Grant Likely <grant.likely@...>
Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@...>
Cc: G Edhaya Chandran <@edhay>
Cc: Eric Jin <eric.jin@...>
Cc: Barton Gao <gaojie@...>

Reviewed-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>