### PR TITLE
uefi-sct/SctPkg: illegal dereference in CheckEbcProtocol()

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestPlatform_uefi.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestPlatform_uefi.c
@@ -3162,12 +3162,6 @@ CheckEbcProtocol (
                         );
     if (!EFI_ERROR (Status) && (SctStriCmp (String, L"yes") == 0)) {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
-      if (!GenTestConfigTitle (IniFile, &AssertionType, L"EBCSupport")) {
-        GenTestConfigContent (L"Ebc->CreateThunk", Ebc->CreateThunk != NULL);
-        GenTestConfigContent (L"Ebc->UnloadImage", Ebc->UnloadImage != NULL);
-        GenTestConfigContent (L"Ebc->RegisterICacheFlush", Ebc->RegisterICacheFlush != NULL);
-        GenTestConfigContent (L"Ebc->GetVersion ", Ebc->GetVersion != NULL);
-      }
     }
   }
 


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3065

If LocateProtocol() has failed, variable Ebc is not valid and we may not dereference it.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Reviewed-by: Grant Likely <grant.likely@arm.com>
Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>