### PR TITLE
uefi-sct/SctPkg: NULL deref in DevicePathToText test

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestCoverage.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestCoverage.c
@@ -1198,8 +1198,12 @@ DevicePathToTextConvertDeviceNodeToTextCoverageTest (
   ((MEDIA_OFFSET_DEVICE_PATH *)pDeviceNode1)->EndingOffset = 0x1234;
   Text = DevicePathToText->ConvertDeviceNodeToText (pDeviceNode1, FALSE, FALSE);
   pDeviceNode2 = SctConvertTextToDeviceNode(Text);
-  ((MEDIA_OFFSET_DEVICE_PATH *)pDeviceNode2)->Reserved = 0;
-
+  SctPrint(L"pDeviceNode2 = %p\n", pDeviceNode2);
+  if (pDeviceNode2 &&
+      ((MEDIA_OFFSET_DEVICE_PATH *)pDeviceNode2)->Length ==
+      sizeof(MEDIA_OFFSET_DEVICE_PATH)) {
+    ((MEDIA_OFFSET_DEVICE_PATH *)pDeviceNode2)->Reserved = 0;
+  }
   if ((pDeviceNode2 != NULL) && (SctCompareMem (pDeviceNode2, pDeviceNode1, SctDevicePathNodeLength(pDeviceNode1)) == 0)) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {


### PR DESCRIPTION
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=3029

Function DevicePathToTextConvertDeviceNodeToTextCoverageTest() tests if
DeviceNodeToText() correctly converts a Relative Offset Range node. After calling SctConvertTextToDeviceNode() it tries to set the field Reserved of the returned device node to 0.

If the tested firmware does not return the expected text
SctConvertTextToDeviceNode() may return NULL or a device node that is shorter than expected. In both cases it is not possible to access the field Reserved.

So we must check both that the returned node is not NULL and that it has the exepected size.

Due to the missing check a NULL dereference was observed when running the SCT on U-Boot.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>
Reviewed-by: Grant Likely <grant.likely@arm.com>