### PR TITLE
uefi-sct/SctPkg: Correct issue with memory protection enabled.

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/UnicodeCollation/BlackBoxTest/UnicodeCollationBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/UnicodeCollation/BlackBoxTest/UnicodeCollationBBTestFunction.c
@@ -337,6 +337,7 @@ BBTestStrLwrFunctionAutoTest (
                                         };
 
   CHAR16                               TestDataSav[MAX_SIZE_OF_STRING + 1];
+  CHAR16                               TestDataRw[MAX_SIZE_OF_STRING + 1];
 
 
 
@@ -368,14 +369,15 @@ BBTestStrLwrFunctionAutoTest (
     //
     // Backup current test data
     //
+    CopyUnicodeString (TestDataRw, TestData[Index]);
     CopyUnicodeString (TestDataSav, TestData[Index]);
 
     //
     // For each test data, test the StrLwr functionality.
     //
-    UnicodeCollation->StrLwr (UnicodeCollation, TestData[Index]);
+    UnicodeCollation->StrLwr (UnicodeCollation, TestDataRw);
 
-    if (CheckStrLwr (TestDataSav, TestData[Index])) {
+    if (CheckStrLwr (TestDataSav, TestDataRw)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -390,15 +392,15 @@ BBTestStrLwrFunctionAutoTest (
                    __FILE__,
                    (UINTN)__LINE__,
                    TestDataSav,
-                   TestData[Index]
+                   TestDataRw
                    );
 
 
-    CopyUnicodeString (TestDataSav, TestData[Index]);
-    UnicodeCollation->StrUpr (UnicodeCollation, TestData[Index]);
-    UnicodeCollation->StrLwr (UnicodeCollation, TestData[Index]);
+    CopyUnicodeString (TestDataSav, TestDataRw);
+    UnicodeCollation->StrUpr (UnicodeCollation, TestDataRw);
+    UnicodeCollation->StrLwr (UnicodeCollation, TestDataRw);
 
-    if (CheckStrEql (TestDataSav, TestData[Index])) {
+    if (CheckStrEql (TestDataSav, TestDataRw)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -413,7 +415,7 @@ BBTestStrLwrFunctionAutoTest (
                    __FILE__,
                    (UINTN)__LINE__,
                    TestDataSav,
-                   TestData[Index]
+                   TestDataRw
                    );
   };
 
@@ -458,6 +460,7 @@ BBTestStrUprFunctionAutoTest (
                                         };
 
   CHAR16                               TestDataSav[MAX_SIZE_OF_STRING + 1];
+  CHAR16                               TestDataRw[MAX_SIZE_OF_STRING + 1];
 
 
 
@@ -490,13 +493,14 @@ BBTestStrUprFunctionAutoTest (
     // Backup current test data
     //
     CopyUnicodeString (TestDataSav, TestData[Index]);
+    CopyUnicodeString (TestDataRw, TestData[Index]);
 
     //
     // For each test data, test the StrUpr functionality.
     //
-    UnicodeCollation->StrUpr (UnicodeCollation, TestData[Index]);
+    UnicodeCollation->StrUpr (UnicodeCollation, TestDataRw);
 
-    if (CheckStrUpr (TestDataSav, TestData[Index])) {
+    if (CheckStrUpr (TestDataSav, TestDataRw)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -511,14 +515,14 @@ BBTestStrUprFunctionAutoTest (
                    __FILE__,
                    (UINTN)__LINE__,
                    TestDataSav,
-                   TestData[Index]
+                   TestDataRw
                    );
 
-    CopyUnicodeString (TestDataSav, TestData[Index]);
-    UnicodeCollation->StrLwr (UnicodeCollation, TestData[Index]);
-    UnicodeCollation->StrUpr (UnicodeCollation, TestData[Index]);
+    CopyUnicodeString (TestDataSav, TestDataRw);
+    UnicodeCollation->StrLwr (UnicodeCollation, TestDataRw);
+    UnicodeCollation->StrUpr (UnicodeCollation, TestDataRw);
 
-    if (CheckStrEql (TestDataSav, TestData[Index])) {
+    if (CheckStrEql (TestDataSav, TestDataRw)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -533,7 +537,7 @@ BBTestStrUprFunctionAutoTest (
                    __FILE__,
                    (UINTN)__LINE__,
                    TestDataSav,
-                   TestData[Index]
+                   TestDataRw
                    );
   };
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/UnicodeCollation2/BlackBoxTest/UnicodeCollation2BBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/UnicodeCollation2/BlackBoxTest/UnicodeCollation2BBTestFunction.c
@@ -335,6 +335,7 @@ BBTestStrLwrFunctionAutoTest (
                                         };
 
   CHAR16                               TestDataSav[MAX_SIZE_OF_STRING + 1];
+  CHAR16                               TestDataRw[MAX_SIZE_OF_STRING + 1];
 
 
 
@@ -367,13 +368,14 @@ BBTestStrLwrFunctionAutoTest (
     // Backup current test data
     //
     CopyUnicodeString (TestDataSav, TestData[Index]);
+    CopyUnicodeString (TestDataRw, TestData[Index]);
 
     //
     // For each test data, test the StrLwr functionality.
     //
-    UnicodeCollation->StrLwr (UnicodeCollation, TestData[Index]);
+    UnicodeCollation->StrLwr (UnicodeCollation, TestDataRw);
 
-    if (CheckStrLwr (TestDataSav, TestData[Index])) {
+    if (CheckStrLwr (TestDataSav, TestDataRw)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -388,15 +390,15 @@ BBTestStrLwrFunctionAutoTest (
                    __FILE__,
                    (UINTN)__LINE__,
                    TestDataSav,
-                   TestData[Index]
+                   TestDataRw
                    );
 
 
-    CopyUnicodeString (TestDataSav, TestData[Index]);
-    UnicodeCollation->StrUpr (UnicodeCollation, TestData[Index]);
-    UnicodeCollation->StrLwr (UnicodeCollation, TestData[Index]);
+    CopyUnicodeString (TestDataSav, TestDataRw);
+    UnicodeCollation->StrUpr (UnicodeCollation, TestDataRw);
+    UnicodeCollation->StrLwr (UnicodeCollation, TestDataRw);
 
-    if (CheckStrEql (TestDataSav, TestData[Index])) {
+    if (CheckStrEql (TestDataSav, TestDataRw)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -411,7 +413,7 @@ BBTestStrLwrFunctionAutoTest (
                    __FILE__,
                    (UINTN)__LINE__,
                    TestDataSav,
-                   TestData[Index]
+                   TestDataRw
                    );
   };
 
@@ -456,6 +458,7 @@ BBTestStrUprFunctionAutoTest (
                                         };
 
   CHAR16                               TestDataSav[MAX_SIZE_OF_STRING + 1];
+  CHAR16                               TestDataRw[MAX_SIZE_OF_STRING + 1];
 
 
 
@@ -488,13 +491,14 @@ BBTestStrUprFunctionAutoTest (
     // Backup current test data
     //
     CopyUnicodeString (TestDataSav, TestData[Index]);
+    CopyUnicodeString (TestDataRw, TestData[Index]);
 
     //
     // For each test data, test the StrUpr functionality.
     //
-    UnicodeCollation->StrUpr (UnicodeCollation, TestData[Index]);
+    UnicodeCollation->StrUpr (UnicodeCollation, TestDataRw);
 
-    if (CheckStrUpr (TestDataSav, TestData[Index])) {
+    if (CheckStrUpr (TestDataSav, TestDataRw)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -509,14 +513,14 @@ BBTestStrUprFunctionAutoTest (
                    __FILE__,
                    (UINTN)__LINE__,
                    TestDataSav,
-                   TestData[Index]
+                   TestDataRw
                    );
 
-    CopyUnicodeString (TestDataSav, TestData[Index]);
-    UnicodeCollation->StrLwr (UnicodeCollation, TestData[Index]);
-    UnicodeCollation->StrUpr (UnicodeCollation, TestData[Index]);
+    CopyUnicodeString (TestDataSav, TestDataRw);
+    UnicodeCollation->StrLwr (UnicodeCollation, TestDataRw);
+    UnicodeCollation->StrUpr (UnicodeCollation, TestDataRw);
 
-    if (CheckStrEql (TestDataSav, TestData[Index])) {
+    if (CheckStrEql (TestDataSav, TestDataRw)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -531,7 +535,7 @@ BBTestStrUprFunctionAutoTest (
                    __FILE__,
                    (UINTN)__LINE__,
                    TestDataSav,
-                   TestData[Index]
+                   TestDataRw
                    );
   };
 


### PR DESCRIPTION
On systems with memory protection enabled the modification of local function initialization data results in permission issue. Make a copy of data prior to modification.

Signed-off-by: Jeff Brasen <jbrasen@nvidia.com>

Reviewed-By: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>