### PR TITLE
uefi-sct/SctPkg: build failure DevicePathToText test

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestCoverage.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestCoverage.c
@@ -1200,7 +1200,7 @@ DevicePathToTextConvertDeviceNodeToTextCoverageTest (
   pDeviceNode2 = SctConvertTextToDeviceNode(Text);
   SctPrint(L"pDeviceNode2 = %p\n", pDeviceNode2);
   if (pDeviceNode2 &&
-      ((MEDIA_OFFSET_DEVICE_PATH *)pDeviceNode2)->Length ==
+      ((MEDIA_OFFSET_DEVICE_PATH *)pDeviceNode2)->Header.Length ==
       sizeof(MEDIA_OFFSET_DEVICE_PATH)) {
     ((MEDIA_OFFSET_DEVICE_PATH *)pDeviceNode2)->Reserved = 0;
   }

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestCoverage.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestCoverage.c
@@ -1198,7 +1198,6 @@ DevicePathToTextConvertDeviceNodeToTextCoverageTest (
   ((MEDIA_OFFSET_DEVICE_PATH *)pDeviceNode1)->EndingOffset = 0x1234;
   Text = DevicePathToText->ConvertDeviceNodeToText (pDeviceNode1, FALSE, FALSE);
   pDeviceNode2 = SctConvertTextToDeviceNode(Text);
-  SctPrint(L"pDeviceNode2 = %p\n", pDeviceNode2);
   if (pDeviceNode2 &&
       ((MEDIA_OFFSET_DEVICE_PATH *)pDeviceNode2)->Header.Length ==
       sizeof(MEDIA_OFFSET_DEVICE_PATH)) {


### PR DESCRIPTION
Ref: https://bugzilla.tianocore.org/show_bug.cgi?id=3029

After commit 75c92b85bf9b ("uefi-sct/SctPkg: NULL deref in DevicePathToText
test") a build failure was observed.

Length is a field in MEDIA_OFFSET_DEVICE_PATH.Header and not in MEDIA_OFFSET_DEVICE_PATH itself.

Fixes: 75c92b85bf9b ("uefi-sct/SctPkg: NULL deref in DevicePathToText test")
Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>