### PR TITLE
edk2-test: Add support for building extra packages

### DIFF
--- a/uefi-sct/SctPkg/build.sh
+++ b/uefi-sct/SctPkg/build.sh
@@ -249,28 +249,20 @@ mkdir -p $DEST_DIR
 cp $EDK_TOOLS_PATH/Source/C/bin/GenBin $DEST_DIR/GenBin
 
 #
-# Build the SCT package
+# Build the packages needed for the SCT
+# Set $DSC_EXTRA to any extra packages needed for the build
 #
-build -p SctPkg/UEFI/UEFI_SCT.dsc -a $SCT_TARGET_ARCH -t $TARGET_TOOLS -b $SCT_BUILD $3 $4 $5 $6 $7 $8 $9
-
-# Check if there is any error
-status=$?
-if test $status -ne 0
-then
-  echo Could not build the UEFI SCT package
-  exit -1
-fi
-
-build -p SctPkg/UEFI/IHV_SCT.dsc -a $SCT_TARGET_ARCH -t $TARGET_TOOLS -b $SCT_BUILD $3 $4 $5 $6 $7 $8 $9
-
-# Check if there is any error
-status=$?
-if test $status -ne 0
-then
-  echo Could not build the IHV SCT package
-  exit -1
-fi
-
+for DSC in SctPkg/UEFI/UEFI_SCT.dsc SctPkg/UEFI/IHV_SCT.dsc $DSC_EXTRA
+do
+	build -p $DSC -a $SCT_TARGET_ARCH -t $TARGET_TOOLS -b $SCT_BUILD $3 $4 $5 $6 $7 $8 $9
+	# Check if there is any error
+	status=$?
+	if test $status -ne 0
+	then
+		echo Could not build package $DSC
+		exit -1
+	fi
+done
 
 #
 # If the argument is clean, then don't have to generate Sct binary.


### PR DESCRIPTION
The build.sh script is very useful for setting up the build environment
before calling the package build. Sometimes additional packages are
needed when building the SCT. (e.g., it is useful to build ShellPkg).
Refactor the build code to allow additional DSCs to be added to the
build.

This patch is useful when building a full SCT image that includes the
EDK2 shell.

Signed-off-by: Grant Likely <grant.likely@arm.com>
Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Cc: Samer El-Haj-Mahmoud <samer.el-haj-mahmoud@arm.com>

Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>
Reviewed-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>