### PR TITLE
uefi-sct/SctPkg: Changed compiler check from greater 5 to equal to 5

### DIFF
--- a/uefi-sct/SctPkg/build.sh
+++ b/uefi-sct/SctPkg/build.sh
@@ -56,7 +56,7 @@ function get_gcc_version
 {
 	gcc_version=$($1 -dumpversion)
 
-	if [ ${gcc_version%%.*} -gt 5 ]; then
+	if [ ${gcc_version%%.*} -ge 5 ]; then
 		gcc_version=5
 	fi
 


### PR DESCRIPTION
gcc compilers versions 5.* also need to be converted from string to integer before testing

Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Eric Jin <eric.jin@intel.com>
Cc: Irene Park <ipark@nvidia.com>
Cc: Heinrich Schuchardt <xypron.glpk@gmx.de>
Cc: Samer El-Haj-Mahmoud <samer.el-haj-mahmoud@arm.com>
Cc: Stuart Yoder <Stuart.Yoder@arm.com>
Signed-off-by: Joseph Hemann <Joseph.heman@arm.com>

Reviewed-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-By: G Edhaya Chandran <edhaya.chandran@arm.com>