### PR TITLE
buildzip: Add CapsuleApp.efi to the SCT zip file

### DIFF
--- a/uefi-sct/SctPkg/buildzip.sh
+++ b/uefi-sct/SctPkg/buildzip.sh
@@ -39,8 +39,8 @@ NUM_CPUS=$((`getconf _NPROCESSORS_ONLN` + 2))
 
 make -j"$NUM_CPUS" -C edk2/BaseTools/
 
-# Build the SCT and the shell
-DSC_EXTRA=ShellPkg/ShellPkg.dsc ./SctPkg/build.sh ${TARGET_ARCH} GCC RELEASE -j"$NUM_CPUS"
+# Build the SCT, CapsuleApp.efi, and the shell
+DSC_EXTRA="ShellPkg/ShellPkg.dsc MdeModulePkg/MdeModulePkg.dsc" ./SctPkg/build.sh ${TARGET_ARCH} GCC RELEASE -j"$NUM_CPUS"
 
 # Assemble all the files that need to be in the zip file
 mkdir -p ${TARGET_ARCH}_SCT/EFI/BOOT
@@ -49,6 +49,9 @@ cp Build/Shell/RELEASE_GCC5/${TARGET_ARCH}/Shell_EA4BB293-2D7F-4456-A681-1F22F42
 mkdir -p ${TARGET_ARCH}_SCT/SCT
 cp -r Build/UefiSct/RELEASE_GCC5/SctPackage${TARGET_ARCH}/${TARGET_ARCH}/* ${TARGET_ARCH}_SCT/SCT/
 cp Build/UefiSct/RELEASE_GCC5/SctPackage${TARGET_ARCH}/SctStartup.nsh ${TARGET_ARCH}_SCT/Startup.nsh
+
+mkdir -p ${TARGET_ARCH}_SCT/Mde
+cp Build/MdeModule/RELEASE_GCC5/${TARGET_ARCH}/CapsuleApp.efi ${TARGET_ARCH}_SCT/Mde
 
 # Copy the SCT Parser tool into the repo
 cp sct_parser/* ${TARGET_ARCH}_SCT/SCT/Sequence/


### PR DESCRIPTION
CapsuleApp.efi is necessary for testing capsule updates of the firmware.
Add it into the default build.

Cc: G Edhaya Chandran <edhaya.chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Signed-off-by: Grant Likely <grant.likely@arm.com>
Reviewed-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>