### PR TITLE
ImageIndex need be corrected to range 1 ~ DescriptorCount.

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Dell Inc. All rights reserved.<BR>
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -208,7 +209,7 @@ CheckForSupportGetImage (
   TestGuid = gFirmwareManagementBBTestConformanceSupportGuid001;
   ResultMessageLabel = L"GetImage, function support check";
 
-  ImageIndex = 0;
+  ImageIndex = 1;
   Image = NULL;
   ImageSize = 0;
 
@@ -283,7 +284,7 @@ CheckForSupportSetImage (
   TestGuid = gFirmwareManagementBBTestConformanceSupportGuid002;
   ResultMessageLabel = L"SetImage, function support check";
 
-  ImageIndex = 0;
+  ImageIndex = 1;
   Image = NULL;
   ImageSize = 0;
   AbortReason = NULL;
@@ -362,7 +363,7 @@ CheckForSupportCheckImage (
   TestGuid = gFirmwareManagementBBTestConformanceSupportGuid003;
   ResultMessageLabel = L"CheckImage, function support check";
 
-  ImageIndex = 0;
+  ImageIndex = 1;
   Image = NULL;
   ImageSize = 0;
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c
@@ -3,6 +3,7 @@
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Dell Inc. All rights reserved.<BR>
   Copyright (c) 2019,Microchip Technology Inc.<BR>
+  Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -209,7 +210,7 @@ CheckForSupportGetImage (
   TestGuid = gFirmwareManagementBBTestConformanceSupportGuid001;
   ResultMessageLabel = L"GetImage, function support check";
 
-  ImageIndex = 0;
+  ImageIndex = 1;
   Image = NULL;
   ImageSize = 0;
 
@@ -284,7 +285,7 @@ CheckForSupportSetImage (
   TestGuid = gFirmwareManagementBBTestConformanceSupportGuid002;
   ResultMessageLabel = L"SetImage, function support check";
 
-  ImageIndex = 0;
+  ImageIndex = 1;
   Image = NULL;
   ImageSize = 0;
   AbortReason = NULL;
@@ -363,7 +364,7 @@ CheckForSupportCheckImage (
   TestGuid = gFirmwareManagementBBTestConformanceSupportGuid003;
   ResultMessageLabel = L"CheckImage, function support check";
 
-  ImageIndex = 0;
+  ImageIndex = 1;
   Image = NULL;
   ImageSize = 0;
 


### PR DESCRIPTION
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3272

The goal of the Support Routine: CheckForSupportGetImage is to detect the
current FMP instance's capability for supporting GetImage().

In current code, "ImageIndex = 0" is the input parameter, but it is
inconsistent with spec -"A unique number identifying the firmware image(s)
within the device. The number is between 1 and DescriptorCount."

It is a bug and need the fix.
The similar errors exist in CheckForSupportSetImage/CheckForSupportCheckImage.

Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Cc: Arvin Chen <arvinx.chen@intel.com>
Signed-off-by: Eric Jin <eric.jin@intel.com>

Reviewed-by: Barton Gao <gaojie@byosoft.com.cn>
Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>