### PR TITLE
uefi-sct/SctPkg: Not create event with TPL_HIGH_LEVEL

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/EventTimerTaskPriorityServices/BlackBoxTest/EventTimerTaskPriorityServicesBBTestCreateEvent.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/EventTimerTaskPriorityServices/BlackBoxTest/EventTimerTaskPriorityServicesBBTestCreateEvent.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2012 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2012, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021, ARM Limited. All rights reserved.
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -190,7 +191,6 @@ BBTestCreateEvent_Conf_Sub1 (
   EFI_TPL             NotifyTpls[] = {
                         TPL_CALLBACK,
                         TPL_NOTIFY,
-                        TPL_HIGH_LEVEL,
                         0
                       };
   EFI_TEST_ASSERTION  AssertionType;
@@ -342,7 +342,6 @@ BBTestCreateEvent_Conf_Sub3 (
   EFI_TPL             NotifyTpls[] = {
                         TPL_CALLBACK,
                         TPL_NOTIFY,
-                        TPL_HIGH_LEVEL,
                         0
                       };
   EFI_TEST_ASSERTION  AssertionType;
@@ -407,7 +406,6 @@ BBTestCreateEvent_Conf_Sub4 (
   EFI_TPL             NotifyTpls[] = {
                         TPL_CALLBACK,
                         TPL_NOTIFY,
-                        TPL_HIGH_LEVEL,
                         0
                       };
   EFI_TEST_ASSERTION  AssertionType;
@@ -482,7 +480,6 @@ BBTestCreateEvent_Func_Sub1 (
   EFI_TPL             NotifyTpls[] = {
                         TPL_CALLBACK,
                         TPL_NOTIFY,
-                        TPL_HIGH_LEVEL,
                         0
                       };
   EFI_TEST_ASSERTION  AssertionType;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/EventTimerTaskPriorityServices/BlackBoxTest/EventTimerTaskPriorityServicesBBTestCreateEventEx.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/EventTimerTaskPriorityServices/BlackBoxTest/EventTimerTaskPriorityServicesBBTestCreateEventEx.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021, ARM Limited. All rights reserved.
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -228,7 +229,6 @@ BBTestCreateEventEx_Conf_Sub1 (
   EFI_TPL             NotifyTpls[] = {
                         TPL_CALLBACK,
                         TPL_NOTIFY,
-                        TPL_HIGH_LEVEL,
                         0
                       };
   EFI_GUID            *EventGroups[] = {
@@ -318,7 +318,6 @@ BBTestCreateEventEx_Conf_Sub2 (
   EFI_TPL             NotifyTpls[] = {
                         TPL_CALLBACK,
                         TPL_NOTIFY,
-                        TPL_HIGH_LEVEL,
                         0
                       };
   EFI_GUID            *EventGroups[] = {
@@ -413,7 +412,6 @@ BBTestCreateEventEx_Conf_Sub3 (
   EFI_TPL             NotifyTpls[] = {
                         TPL_CALLBACK,
                         TPL_NOTIFY,
-                        TPL_HIGH_LEVEL,
                         0
                       };
   EFI_GUID            *EventGroups[] = {


### PR DESCRIPTION
The commits a9d1fb58 and ae7e5477b555 caused SCT BS.CreateEvent failures.

Section 7.1 of the UEFI Spec states that TPL_HIGH_LEVEL is designed for
exclusive use by the firmware. The creation of events by UEFI
applications, UEFI drivers, and UEFI OS Loaders should not use this TPL
level.

Therefore, revert TPL_HIGH_LEVEL change in commits a9d1fb58 and
ae7e5477b555 to not create event with TPL_HIGH_LEVEL to be compliant
with UEFI Spec and fix the failures.

For more information, https://edk2.groups.io/g/devel/message/76338

Cc: Samer El-Haj-Mahmoud <samer.el-haj-mahmoud@arm.com>
Cc: G Edhaya Chandran <edhaya.chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Cc: Heinrich Schuchardt <xypron.glpk@gmx.de>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Signed-off-by: Sunny Wang <sunny.wang@arm.com>

Reviewed-By: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-By: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>