### PR TITLE
SctPkg: Consume MdeLibs.dsc.inc for RegisterFilterLib

### DIFF
--- a/uefi-sct/SctPkg/UEFI/IHV_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/IHV_SCT.dsc
@@ -136,6 +136,8 @@
 
 [Libraries.IA32,Libraries.X64]
 
+!include MdePkg/MdeLibs.dsc.inc
+
 [LibraryClasses.common]
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf

--- a/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
@@ -138,6 +138,8 @@
 [Libraries.RISCV64]
   ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
+!include MdePkg/MdeLibs.dsc.inc
+
 [LibraryClasses.common]
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3246

MdeLibs.dsc.inc was added for some basic/default library
instances provided by MdePkg, RegisterFilterLibNull which will be
consumed by IoLib and BaseLib was added in MdeLibs.dsc.inc.

To build UefiSct with edk2-stable202105 and later, this file
must be included in dsc file.

Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Cc: Eric Jin <eric.jin@intel.com>
Cc: Arvin Chen <arvinx.chen@intel.com>

Signed-off-by: Barton Gao <gaojie@byosoft.com.cn>
Reviewed-by: Sunny Wang <sunny.wang@arm.com>
Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>