### PR TITLE
uefi-sct/SctPkg: Update page alignment calculations

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MemoryAllocationServices/BlackBoxTest/MemoryAllocationServicesBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MemoryAllocationServices/BlackBoxTest/MemoryAllocationServicesBBTestFunction.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2013 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2013, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2021, ARM Limited. All rights reserved.
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -701,13 +702,16 @@ BBTestAllocatePagesInterfaceTest (
         Start   = Descriptor.PhysicalStart;
 
         //
-        // Some memory types need more alignment than 4K, so
+        // Calculate New Start address and PageNum with 64k alignment to
+        // cover the case that some memory types' alignment is more than
+        // 4k. If the available memory is less than 192k, the memory
+        // allocation call will be skipped.
         //
-        if (PageNum <= 0x10) {
+        if (PageNum < (3 * EFI_SIZE_TO_PAGES(0x10000))) {
           break;
         }
         Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
-        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
+        PageNum = PageNum - (2 * EFI_SIZE_TO_PAGES(0x10000));
 
         Memory  = Start;
 
@@ -831,13 +835,16 @@ BBTestAllocatePagesInterfaceTest (
         Start   = Descriptor.PhysicalStart;
 
         //
-        // Some memory types need more alignment than 4K, so
+        // Calculate New Start address and PageNum with 64k alignment to
+        // cover the case that some memory types' alignment is more than
+        // 4k. If the available memory is less than 192k, the memory
+        // allocation call will be skipped.
         //
-        if (PageNum <= 0x10) {
+        if (PageNum < (3 * EFI_SIZE_TO_PAGES(0x10000))) {
           break;
         }
         Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
-        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
+        PageNum = PageNum - (2 * EFI_SIZE_TO_PAGES(0x10000));
 
         Memory  = Start;
 
@@ -954,13 +961,16 @@ BBTestAllocatePagesInterfaceTest (
         Start   = Descriptor.PhysicalStart;
 
         //
-        // Some memory types need more alignment than 4K, so
+        // Calculate New Start address and PageNum with 64k alignment to
+        // cover the case that some memory types' alignment is more than
+        // 4k. If the available memory is less than 192k, the memory
+        // allocation call will be skipped.
         //
-        if (PageNum <= 0x10) {
+        if (PageNum < (3 * EFI_SIZE_TO_PAGES(0x10000))) {
           break;
         }
         Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
-        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
+        PageNum = PageNum - (2 * EFI_SIZE_TO_PAGES(0x10000));
 
         Memory = Start + (SctLShiftU64 (PageNum/3, EFI_PAGE_SHIFT) & 0xFFFFFFFFFFFF0000);
 
@@ -1077,13 +1087,16 @@ BBTestAllocatePagesInterfaceTest (
         Start   = Descriptor.PhysicalStart;
 
         //
-        // Some memory types need more alignment than 4K, so
+        // Calculate New Start address and PageNum with 64k alignment to
+        // cover the case that some memory types' alignment is more than
+        // 4k. If the available memory is less than 192k, the memory
+        // allocation call will be skipped.
         //
-        if (PageNum <= 0x10) {
+        if (PageNum < (3 * EFI_SIZE_TO_PAGES(0x10000))) {
           break;
         }
         Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
-        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
+        PageNum = PageNum - (2 * EFI_SIZE_TO_PAGES(0x10000));
 
         Memory  = Start + (SctLShiftU64 (PageNum * 2 / 3, EFI_PAGE_SHIFT) & 0xFFFFFFFFFFFF0000);
 
@@ -1207,13 +1220,16 @@ BBTestAllocatePagesInterfaceTest (
         Start   = Descriptor.PhysicalStart;
 
         //
-        // Some memory types need more alignment than 4K, so
+        // Calculate New Start address and PageNum with 64k alignment to
+        // cover the case that some memory types' alignment is more than
+        // 4k. If the available memory is less than 192k, the memory
+        // allocation call will be skipped.
         //
-        if (PageNum <= 0x10) {
+        if (PageNum < (3 * EFI_SIZE_TO_PAGES(0x10000))) {
           break;
         }
         Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
-        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
+        PageNum = PageNum - (2 * EFI_SIZE_TO_PAGES(0x10000));
 
         Memory  = Start;
 
@@ -1330,13 +1346,16 @@ BBTestAllocatePagesInterfaceTest (
         Start   = Descriptor.PhysicalStart;
 
         //
-        // Some memory types need more alignment than 4K, so
+        // Calculate New Start address and PageNum with 64k alignment to
+        // cover the case that some memory types' alignment is more than
+        // 4k. If the available memory is less than 192k, the memory
+        // allocation call will be skipped.
         //
-        if (PageNum <= 0x10) {
+        if (PageNum < (3 * EFI_SIZE_TO_PAGES(0x10000))) {
           break;
         }
         Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
-        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
+        PageNum = PageNum - (2 * EFI_SIZE_TO_PAGES(0x10000));
 
         Memory  = Start;
 
@@ -1469,13 +1488,16 @@ BBTestAllocatePagesInterfaceTest (
         Start   = Descriptor.PhysicalStart;
 
         //
-        // Some memory types need more alignment than 4K, so
+        // Calculate New Start address and PageNum with 64k alignment to
+        // cover the case that some memory types' alignment is more than
+        // 4k. If the available memory is less than 192k, the memory
+        // allocation call will be skipped.
         //
-        if (PageNum <= 0x10) {
+        if (PageNum < (3 * EFI_SIZE_TO_PAGES(0x10000))) {
           break;
         }
         Start   = (Start + 0xFFFF) & 0xFFFFFFFFFFFF0000;
-        PageNum = PageNum - EFI_SIZE_TO_PAGES(0x10000);
+        PageNum = PageNum - (2 * EFI_SIZE_TO_PAGES(0x10000));
 
         Memory  = Start;
 


### PR DESCRIPTION
This is to fix the SCT BS.AllocatePages failures (not found) with the case that the Start address is not aligned to 64k.
For example,
  The following is available memory region for testing:
    0000000082012000-00000000EB6D9FFF 00000000000696C8
  With the current page alignment calculation, we will get:
    Start address is 0x82020000
    PageNum is 0x696B8
  In BS.AllocatePages, it will make the end address align with 64k,
  so PageNum will be changed from 0x696B8 to 0x696C0. Therefore, the
  end address will become 0xEB6E0000 which is larger than 0xEB6D9FFF,
  so we get not found error in the end.

Therefore, the calculation for getting the PageNum should be updated to PageNum - (2 * EFI_SIZE_TO_PAGES(0x10000)) so that we won't get a wrong PageNum to allocate a memory with a size larger than available space's size.

With this solution, the example above will get 0x696A8 as calculated PageNum. Then, in BS.AllocatePages, the PageNum will be changed from
0x696A8 to 0x696B0. Therefore, the end address will become 0xEB6D0000 that is smaller than 0xEB6D9FFF, so we get not found error in the end.

I also tested this solution on two ARM platforms (NXP1046A and RPi4).

Cc: Samer El-Haj-Mahmoud <samer.el-haj-mahmoud@arm.com>
Cc: G Edhaya Chandran <edhaya.chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Signed-off-by: Sunny Wang <sunny.wang@arm.com>

Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>
Reviewed-by: Tuan Phan <tuanphan@os.amperecomputing.com>