### PR TITLE
uefi-sct/SctPkg: uefi-sct:QueryVariableInfo(EFI_VARIABLE_NON_VOLATILE)

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/VariableServices/BlackBoxTest/VariableServicesBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/VariableServices/BlackBoxTest/VariableServicesBBTestConformance.c
@@ -3399,6 +3399,7 @@ QueryVariableInfoConfTestSub5 (
 {
   EFI_STATUS            Status;
   UINT32                InvalidAttributes[] = {
+                          EFI_VARIABLE_NON_VOLATILE,
                           EFI_VARIABLE_RUNTIME_ACCESS,
                           EFI_VARIABLE_NON_VOLATILE|EFI_VARIABLE_RUNTIME_ACCESS,
                           0


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3469

The Self Certification Test (SCT) II Case Specification, 2017 requires
in 5.2.1.4.5. that QueryVariableInfo() shall fail for

    attributes = EFI_VARIABLE_NON_VOLATILE.

Add EFI_VARIABLE_NON_VOLATILE to tested values in function
QueryVariableInfoConfTestSub5().

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>

Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>