### PR TITLE
uefi-sct: Propose maintainers from AMD

### DIFF
--- a/uefi-sct/Maintainers.txt
+++ b/uefi-sct/Maintainers.txt
@@ -41,10 +41,12 @@ UEFI-SCT:
 
 M: G Edhaya Chandran <Edhaya.Chandran@arm.com>
 M: Barton Gao <gaojie@byosoft.com.cn>
+M: Carolyn Gjertsen <Carolyn.Gjertsen@amd.com>
 
 R: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
 R: Eric Jin <eric.jin@intel.com>
 R: Arvin Chen <arvinx.chen@intel.com>
+R: Supreeth Venkatesh <Supreeth.Venkatesh@amd.com>
 
 General questions on UEFI-SCT with the subject [edk2-test] can be sent to
 L: edk2-devel <devel@edk2.groups.io>


### PR DESCRIPTION
This patch proposes Carolyn Gjertsen as maintainer of edk2-test
repository and Supreeth Venkatesh as reviewer from AMD.

Signed-off-by: Supreeth Venkatesh <supreeth.venkatesh@amd.com>
Reviewed-By: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>