### PR TITLE
uefi-sct/SctPkg: unsupported TEXT_INPUT_EX.SetState

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestFunction.c
@@ -1182,6 +1182,9 @@ BBTestReadKeyStrokeExFunctionAutoTestCheckpoint1 (
                                 SimpleTextInputEx,
                                 &State
                                 );
+  if (Status == EFI_UNSUPPORTED) {
+    return EFI_UNSUPPORTED;
+  }
 
   if (EFI_ERROR(Status)) {
     StandardLib->RecordAssertion (

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestFunction.c
@@ -1182,6 +1182,9 @@ BBTestReadKeyStrokeExFunctionAutoTestCheckpoint1 (
                                 SimpleTextInputEx,
                                 &State
                                 );
+  if (Status == EFI_UNSUPPORTED) {
+    return EFI_UNSUPPORTED;
+  }
 
   if (EFI_ERROR(Status)) {
     StandardLib->RecordAssertion (


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3390

According to the UEFI specification
EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL.SetState() may return EFI_UNSUPPORTED if
"the device does not support the ability to have its state set."

BBTestReadKeyStrokeExFunctionAutoTestCheckpoint1() must not report an error
in this case.

Fixes: e9c21711c17 ("uefi-sct/SctPkg:Add checkpoint of ReadKeyStrokeEx Toggle state")
Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>

Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>