### PR TITLE
uefi-sct/SctPkg: fix BuildAtaDeviceNode()

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestMain.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestMain.c
@@ -1162,9 +1162,9 @@ BuildAtaDeviceNode (
 
   Status = GetNextRequiredParam(&TextDeviceNode, L"Controller", &ParamIdentifierStr, &ParamIdentifierVal);
   if ((!EFI_ERROR(Status)) && (ParamIdentifierVal != NULL)) {
-  	if ((SctStrCmp (ParamIdentifierVal, L"Primary") == 0) || (SctStrCmp(ParamIdentifierVal, L"0"))) {
+    if ((SctStrCmp (ParamIdentifierVal, L"Primary") == 0) || (SctStrCmp(ParamIdentifierVal, L"0") == 0)) {
       Atapi->PrimarySecondary = 0;
-    } else if ((SctStrCmp (ParamIdentifierVal, L"Secondary") == 0) || (SctStrCmp(ParamIdentifierVal, L"1"))) {
+    } else if ((SctStrCmp (ParamIdentifierVal, L"Secondary") == 0) || (SctStrCmp(ParamIdentifierVal, L"1") == 0)) {
       Atapi->PrimarySecondary = 1;
     } else {
       goto InValidText;
@@ -1175,9 +1175,9 @@ BuildAtaDeviceNode (
 
   Status = GetNextRequiredParam(&TextDeviceNode, L"Drive", &ParamIdentifierStr, &ParamIdentifierVal);
   if ((!EFI_ERROR(Status)) && (ParamIdentifierVal != NULL)) {
-  	if ((SctStrCmp (ParamIdentifierVal, L"Master") == 0) || (SctStrCmp(ParamIdentifierVal, L"0"))) {
+    if ((SctStrCmp (ParamIdentifierVal, L"Master") == 0) || (SctStrCmp(ParamIdentifierVal, L"0") == 0)) {
       Atapi->SlaveMaster = 0;
-    } else if ((SctStrCmp (ParamIdentifierVal, L"Slave") == 0) || (SctStrCmp(ParamIdentifierVal, L"1"))) {
+    } else if ((SctStrCmp (ParamIdentifierVal, L"Slave") == 0) || (SctStrCmp(ParamIdentifierVal, L"1") == 0)) {
       Atapi->SlaveMaster = 1;
     } else {
       goto InValidText;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3290

When BuildAtaDeviceNode() is called with L"Ata(0,0,0)" it creates a node
Ata(1,1,0). This leads to test to an assertion failed test result

    ../DevicePathToTextBBTestFunction.c:332:
    Convert result: Ata(0,0,0) - Expected: Ata(Primary,Master,0)

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
Reviewed-by: G Edhaya Chandran<edhaya.chandran@arm.com>