### PR TITLE
uefi-sct/SctPkg: Allow some SNP functions to return EFI_UNSUPPORTED

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PxeBaseCode/BlackBoxTest/PxeBaseCodeBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PxeBaseCode/BlackBoxTest/PxeBaseCodeBBTestFunction.c
@@ -2,15 +2,16 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2022, ARM Limited. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
-  which accompanies this distribution.  The full text of the license may be found at 
+  which accompanies this distribution.  The full text of the license may be found at
   http://opensource.org/licenses/bsd-license.php
- 
+
   THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
- 
+
 **/
 /*++
 
@@ -203,7 +204,7 @@ BBTestUdpReadFuncSrcPortFilter (
 
 /**
  *  Entrypoint for EFI_PXE_BASE_CODE_PROTOCOL.Start() Function Test.
- *  It is the new case to add IPv6 into the test scope. The original test case is switched off. 
+ *  It is the new case to add IPv6 into the test scope. The original test case is switched off.
  *  @param This a pointer of EFI_BB_TEST_PROTOCOL.
  *  @param ClientInterface a pointer to the interface to be tested.
  *  @param TestLevel test "thoroughness" control.
@@ -380,7 +381,7 @@ BBTestNewStartFunctionTest (
                      L"Mode->PxeBisReplyReceived - %s\r\n",
                      BcInterface->Mode->PxeBisReplyReceived ? L"TRUE" : L"FALSE"
                      );
-    }   
+    }
     if (BcInterface->Mode->IcmpErrorReceived != FALSE) {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
       StandardLib->RecordMessage (
@@ -605,7 +606,7 @@ BBTestNewStartFunctionTest (
         return Status;
       }
     }
-    
+
     //
     // Enable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface in IPv6
     //
@@ -627,8 +628,8 @@ BBTestNewStartFunctionTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    
-    
+
+
     if (AssertionType == EFI_TEST_ASSERTION_PASSED) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
       if (BcInterface->Mode->Started != TRUE) {
@@ -720,7 +721,7 @@ BBTestNewStartFunctionTest (
                        L"Mode->PxeBisReplyReceived - %s\r\n",
                        BcInterface->Mode->PxeBisReplyReceived ? L"TRUE" : L"FALSE"
                        );
-      }   
+      }
       if (BcInterface->Mode->IcmpErrorReceived != FALSE) {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
         StandardLib->RecordMessage (
@@ -797,7 +798,7 @@ BBTestNewStartFunctionTest (
                        L"IS_PXE_PACKET_ZEROED(Mode->ProxyOffer) - Fail\r\n"
                        );
       }
-    
+
       if (IS_PXE_PACKET_ZEROED(&BcInterface->Mode->PxeDiscover) == FALSE) {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
         StandardLib->RecordMessage (
@@ -944,13 +945,13 @@ BBTestNewStartFunctionTest (
                      );
     }
   }
-  
+
   return Status;
 }
 
 /**
  *  Entrypoint for EFI_PXE_BASE_CODE_PROTOCOL.Statistics() Function Test.
- *  It is the new case to add IPv6 into the test scope. The original test case is switched off. 
+ *  It is the new case to add IPv6 into the test scope. The original test case is switched off.
  *  @param This a pointer of EFI_BB_TEST_PROTOCOL.
  *  @param ClientInterface a pointer to the interface to be tested.
  *  @param TestLevel test "thoroughness" control.
@@ -974,7 +975,7 @@ BBTestNewSetIpFilterFunctionTest (
   UINT8                                  Index;
 
   Index = 0;
-  
+
   //
   // Get the Standard Library Interface
   //
@@ -1091,7 +1092,7 @@ BBTestNewSetIpFilterFunctionTest (
         return Status;
       }
     }
-    
+
     //
     // Enable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface in IPv6
     //
@@ -1109,16 +1110,16 @@ BBTestNewSetIpFilterFunctionTest (
                      );
       return Status;
     }
-    
+
     SctSetMem (&BcIpFilter, sizeof (BcIpFilter), 0);
     BcIpFilter.Filters = EFI_PXE_BASE_CODE_IP_FILTER_STATION_IP;
     BcIpFilter.IpCnt = 2;
-    
+
     for (Index = 0; Index < 16; Index++) {
       BcIpFilter.IpList[0].v6.Addr[Index] = Index;
       BcIpFilter.IpList[1].v6.Addr[Index] = 16 - Index;
     }
-    
+
     Status = BcInterface->SetIpFilter (BcInterface, &BcIpFilter);
     if (Status == EFI_SUCCESS) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
@@ -1135,7 +1136,7 @@ BBTestNewSetIpFilterFunctionTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    
+
     if (TRUE == IsIpFilterEqual (&BcIpFilter, &(BcInterface->Mode->IpFilter))){
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
@@ -1158,7 +1159,7 @@ BBTestNewSetIpFilterFunctionTest (
 
 /**
  *  Entrypoint for EFI_PXE_BASE_CODE_PROTOCOL.Stop() Function Test.
- *  It is the new case to add IPv6 into the test scope. The original test case is switched off. 
+ *  It is the new case to add IPv6 into the test scope. The original test case is switched off.
  *  @param This a pointer of EFI_BB_TEST_PROTOCOL.
  *  @param ClientInterface a pointer to the interface to be tested.
  *  @param TestLevel test "thoroughness" control.
@@ -1290,7 +1291,7 @@ BBTestNewStopFunctionTest (
                  __FILE__,
                  (UINTN)__LINE__,
                  Status
-                 );  
+                 );
 
   return Status;
 }
@@ -1607,8 +1608,8 @@ BBTestStartFunctionTest (
                    );
   }
   if  ((0 != BcInterface->Mode->IpFilter.Filters) || (0 != BcInterface->Mode->IpFilter.IpCnt)) {
-  	AssertionType = EFI_TEST_ASSERTION_FAILED;
-	StandardLib->RecordMessage (
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    StandardLib->RecordMessage (
                    StandardLib,
                    EFI_VERBOSE_LEVEL_DEFAULT,
                    L"The Mode->IpFilter.Filters or Mode->IpFilter.IpCnt field is not 0\r\n");
@@ -2032,6 +2033,7 @@ BBTestMtftpFunctionTest (
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   UINTN                                  FileSize;
+  EFI_TEST_ASSERTION                     AssertionType;
 
   //
   // Get support library (Standard Lib, Profile Lib, Logging Lib)
@@ -2098,11 +2100,15 @@ BBTestMtftpFunctionTest (
   }
 
   Status = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  if (EFI_ERROR(Status))
-  {
+  if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
-                   EFI_TEST_ASSERTION_FAILED,
+                   AssertionType,
                    gTestGenericFailureGuid,
                    L"EFI_PXE_BASE_CODE_PROTOCOL.ARP - Reset Current MAC",
                    L"%a:%d:Status - %r",
@@ -2208,6 +2214,7 @@ BBTestUdpWriteFunctionTest (
   EFI_STATUS                             Status;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
+  EFI_TEST_ASSERTION                    AssertionType;
 
   //
   // Get the Standard Library Interface
@@ -2296,11 +2303,15 @@ BBTestUdpWriteFunctionTest (
   }
 
   Status = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  if (EFI_ERROR(Status))
-  {
+  if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
-                   EFI_TEST_ASSERTION_FAILED,
+                   AssertionType,
                    gTestGenericFailureGuid,
                    L"EFI_PXE_BASE_CODE_PROTOCOL.ARP - Reset Current MAC",
                    L"%a:%d:Status - %r",
@@ -2378,6 +2389,7 @@ BBTestUdpReadFunctionTest (
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
   EFI_PXE_BASE_CODE_IP_FILTER            BcIpFilter;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
+  EFI_TEST_ASSERTION                     AssertionType;
 
   //
   // Get the Support Library Interface
@@ -2473,8 +2485,12 @@ BBTestUdpReadFunctionTest (
   }
 
   Status = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  if (EFI_ERROR(Status))
-  {
+  if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
                    EFI_TEST_ASSERTION_FAILED,
@@ -2755,8 +2771,12 @@ BBTestArpFunctionTest (
   }
 
   Status = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  if (EFI_ERROR(Status))
-  {
+  if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
                    EFI_TEST_ASSERTION_FAILED,

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestConformance.c
@@ -2,15 +2,16 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2022, ARM Limited. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
-  which accompanies this distribution.  The full text of the license may be found at 
+  which accompanies this distribution.  The full text of the license may be found at
   http://opensource.org/licenses/bsd-license.php
- 
+
   THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
- 
+
 **/
 /*++
 
@@ -100,7 +101,7 @@ BBTestStartConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // restore SNP status
   //
@@ -108,7 +109,7 @@ BBTestStartConformanceTest (
     Status1 = SnpInterface->Initialize(SnpInterface, 0, 0);
     if (EFI_ERROR(Status1)) {
       return Status1;
-    }  
+    }
   }
 
   StandardLib->RecordAssertion (
@@ -206,7 +207,7 @@ BBTestStopConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Restore SNP status
   //
@@ -311,10 +312,10 @@ BBTestInitializeConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Restore SNP status
-  // 
+  //
   if (State1 != EfiSimpleNetworkStopped) {
     Status1 = SnpInterface->Start (SnpInterface);
     if (EFI_ERROR(Status1)) {
@@ -332,7 +333,7 @@ BBTestInitializeConformanceTest (
     }
   }
 
-  
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType,
@@ -416,16 +417,19 @@ BBTestResetConformanceTest (
   // Call Reset() function when network interface not start.
   //
   Status = SnpInterface->Reset (SnpInterface, FALSE);
-
   if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
-  
+
   //
   // Restore SNP status
-  // 
+  //
   if (State1 != EfiSimpleNetworkStopped) {
     Status1 = SnpInterface->Start (SnpInterface);
     if (EFI_ERROR(Status1)) {
@@ -450,7 +454,7 @@ BBTestResetConformanceTest (
                  (UINTN)__LINE__,
                  Status
                  );
- 
+
 
   return EFI_SUCCESS;
 }
@@ -528,7 +532,7 @@ BBTestShutdownConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Restore SNP status
   //
@@ -626,31 +630,26 @@ BBTestReceiveFilterConformanceTest (
   // Call ReceiveFilters() function if network interface not start.
   //
   Status = SnpInterface->ReceiveFilters (SnpInterface, 0, 0, FALSE, 0, NULL);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"ReceiveFilters isn't supported, Status - %r\n",
-                   Status
-                   );
+  if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid006,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() when network interface not start.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid006,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() when network interface not start.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
+
 
   //
   // Assertion Point 5.6.2.2
@@ -662,31 +661,25 @@ BBTestReceiveFilterConformanceTest (
   }
 
   Status = SnpInterface->ReceiveFilters (SnpInterface, 0, 0, FALSE, 0, NULL);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"ReceiveFilters isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_DEVICE_ERROR) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_DEVICE_ERROR) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid007,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() when network interface not initialized.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid007,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() when network interface not initialized.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Assertion Point 5.6.2.3
@@ -701,31 +694,25 @@ BBTestReceiveFilterConformanceTest (
   //  Call ReceiveFilters with invalide Enable
   //
   Status = SnpInterface->ReceiveFilters (SnpInterface, ~(SnpInterface->Mode->ReceiveFilterMask), 0, FALSE, 0, NULL);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"ReceiveFilters isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_INVALID_PARAMETER) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid008,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid Enable.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid008,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid Enable.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   //  Call ReceiveFilters with invalide MCastFilterCnt
@@ -740,85 +727,67 @@ BBTestReceiveFilterConformanceTest (
     MAC.Addr[5] = 0x02;
 
     Status = SnpInterface->ReceiveFilters (SnpInterface, EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST, 0, FALSE, SnpInterface->Mode->MaxMCastFilterCount + 1, &MAC);
-    if (Status == EFI_UNSUPPORTED) {
-      StandardLib->RecordMessage(
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_QUIET,
-                     L"ReceiveFilters isn't supported, Status - %r\n",
-                     Status
-                     );
+    if (Status == EFI_INVALID_PARAMETER) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      if (Status == EFI_INVALID_PARAMETER) {
+      if (EFI_UNSUPPORTED == Status) {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
       } else {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
       }
-
-      StandardLib->RecordAssertion (
-                     StandardLib,
-                     AssertionType,
-                     gSimpleNetworkBBTestConformanceAssertionGuid009,
-                     L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid MCastFilterCnt is greater than Snp->Mode->MaxMCastFilterCount.",
-                     L"%a:%d:Status - %r",
-                     __FILE__,
-                     (UINTN)__LINE__,
-                     Status
-                     );
     }
+    StandardLib->RecordAssertion (
+                    StandardLib,
+                    AssertionType,
+                    gSimpleNetworkBBTestConformanceAssertionGuid009,
+                    L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid MCastFilterCnt is greater than Snp->Mode->MaxMCastFilterCount.",
+                    L"%a:%d:Status - %r",
+                    __FILE__,
+                    (UINTN)__LINE__,
+                    Status
+                    );
 
     Status = SnpInterface->ReceiveFilters (SnpInterface, EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST, 0, FALSE, 0, &MAC);
-    if (Status == EFI_UNSUPPORTED) {
-      StandardLib->RecordMessage(
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_QUIET,
-                     L"ReceiveFilters isn't supported, Status - %r\n",
-                     Status
-                     );
+    if (Status == EFI_INVALID_PARAMETER) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      if (Status == EFI_INVALID_PARAMETER) {
+      if (EFI_UNSUPPORTED == Status) {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
       } else {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
       }
-
-      StandardLib->RecordAssertion (
-                     StandardLib,
-                     AssertionType,
-                     gSimpleNetworkBBTestConformanceAssertionGuid043,
-                     L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid MCastFilterCnt is 0.",
-                     L"%a:%d:Status - %r",
-                     __FILE__,
-                     (UINTN)__LINE__,
-                     Status
-                     );
     }
+    StandardLib->RecordAssertion (
+                    StandardLib,
+                    AssertionType,
+                    gSimpleNetworkBBTestConformanceAssertionGuid043,
+                    L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid MCastFilterCnt is 0.",
+                    L"%a:%d:Status - %r",
+                    __FILE__,
+                    (UINTN)__LINE__,
+                    Status
+                    );
 
     Status = SnpInterface->ReceiveFilters (SnpInterface, EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST, 0, FALSE, 1, NULL);
-    if (Status == EFI_UNSUPPORTED) {
-      StandardLib->RecordMessage(
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_QUIET,
-                     L"ReceiveFilters isn't supported, Status - %r\n",
-                     Status
-                     );
+    if (Status == EFI_INVALID_PARAMETER) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      if (Status == EFI_INVALID_PARAMETER) {
+      if (EFI_UNSUPPORTED == Status) {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
       } else {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
       }
-
-      StandardLib->RecordAssertion (
-                       StandardLib,
-                       AssertionType,
-                       gSimpleNetworkBBTestConformanceAssertionGuid010,
-                       L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with MCastFilterCnt not match MCastFilter.",
-                       L"%a:%d:Status - %r",
-                       __FILE__,
-                       (UINTN)__LINE__,
-                       Status
-                       );
     }
+    StandardLib->RecordAssertion (
+                      StandardLib,
+                      AssertionType,
+                      gSimpleNetworkBBTestConformanceAssertionGuid010,
+                      L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with MCastFilterCnt not match MCastFilter.",
+                      L"%a:%d:Status - %r",
+                      __FILE__,
+                      (UINTN)__LINE__,
+                      Status
+                      );
   }
 
   //
@@ -912,7 +881,7 @@ BBTestStationAddressConformanceTest (
   // save current snp state
   //
   State2 = SnpInterface->Mode->State;
-  
+
   //
   // Assertion Point 5.7.2.2
   // Call StationAddress() function if network interface not initialized.
@@ -923,71 +892,60 @@ BBTestStationAddressConformanceTest (
   }
 
   StatusBuf[1] = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  
+
   //
   // Restore SNP Status
   //
   if (State1 == EfiSimpleNetworkInitialized) {
-    Status = SnpInterface->Initialize(SnpInterface, 0, 0); 
+    Status = SnpInterface->Initialize(SnpInterface, 0, 0);
     if (EFI_ERROR(Status)){
       return Status;
     }
   }
-  
-  if ((StatusBuf[0] == EFI_INVALID_PARAMETER) || (StatusBuf[0] == EFI_UNSUPPORTED)) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"StationAddress isn't supported, Status - %r\n",
-                   StatusBuf[0]
-                   );
+
+  if ((StatusBuf[0] == EFI_NOT_STARTED) && (State2 == EfiSimpleNetworkStopped)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((StatusBuf[0] == EFI_NOT_STARTED) && (State2 == EfiSimpleNetworkStopped)) {
+    if ((StatusBuf[0] == EFI_INVALID_PARAMETER) || (StatusBuf[0] == EFI_UNSUPPORTED)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid011,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke StationAddress() when network interface not start.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[0]
-                   );
   }
-  
-  if ((StatusBuf[1] == EFI_INVALID_PARAMETER) || (StatusBuf[1] == EFI_UNSUPPORTED)) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"StationAddress isn't supported, Status - %r\n",
-                   StatusBuf[1]
-                   );
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid011,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke StationAddress() when network interface not start.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[0]
+                  );
+
+
+  if (StatusBuf[1] == EFI_DEVICE_ERROR) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (StatusBuf[1] == EFI_DEVICE_ERROR) {
+    if ((StatusBuf[1] == EFI_INVALID_PARAMETER) || (StatusBuf[1] == EFI_UNSUPPORTED)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid012,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke StationAddress() when network interface not initialized.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[1]
-                   );
   }
-  
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid012,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke StationAddress() when network interface not initialized.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[1]
+                  );
+
   if (State1 == EfiSimpleNetworkStopped) {
-    Status = SnpInterface->Stop (SnpInterface); 
+    Status = SnpInterface->Stop (SnpInterface);
     if (EFI_ERROR(Status)){
       return Status;
     }
@@ -1067,30 +1025,25 @@ BBTestStatisticsConformanceTest (
   // Call Statistics() function while network interface is not started.
   //
   Status = SnpInterface->Statistics (SnpInterface, FALSE, &StatisticsSize, &StatisticsTable);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"Statistics isn't supported, Status - %r\n",
-                   Status
-                   );
+  if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid014,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() while network interface not started.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid014,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() while network interface not started.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Assertion Point 5.8.2.2
@@ -1102,30 +1055,25 @@ BBTestStatisticsConformanceTest (
   }
 
   Status = SnpInterface->Statistics (SnpInterface, FALSE, &StatisticsSize, &StatisticsTable);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"Statistics isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_DEVICE_ERROR) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_DEVICE_ERROR) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid015,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() while network interface is not initialized.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid015,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() while network interface is not initialized.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Assertion Point 5.8.2.3
@@ -1143,30 +1091,25 @@ BBTestStatisticsConformanceTest (
   StatisticsSize = 0;
 
   Status = SnpInterface->Statistics (SnpInterface, FALSE, &StatisticsSize, &StatisticsTable);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"Statistics isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_BUFFER_TOO_SMALL) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_BUFFER_TOO_SMALL) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid017,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() with small buffer.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid017,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() with small buffer.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Restore SNP State
@@ -1182,7 +1125,7 @@ BBTestStatisticsConformanceTest (
       return Status;
     }
   }
-  
+
   return EFI_SUCCESS;
 }
 
@@ -1267,7 +1210,7 @@ BBTestMCastIpToMacConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Restore SNP status
   //
@@ -1405,7 +1348,7 @@ BBTestNVDataConformanceTest (
 
   StatusBuf[0] = SnpInterface->NvData (SnpInterface, TRUE, 0, SnpInterface->Mode->NvRamAccessSize, Buffer);
   CheckPoint1State = SnpInterface->Mode->State;
-  
+
 
   //
   // Assertion Point 5.10.2.2
@@ -1425,119 +1368,102 @@ BBTestNVDataConformanceTest (
   // Check Point A: "Offset" not be a multiple of NvRamAccessSize
   //
   StatusBuf[1] = SnpInterface->NvData (SnpInterface, TRUE, (SnpInterface->Mode->NvRamAccessSize/2), SnpInterface->Mode->NvRamAccessSize, Buffer);
- 
+
 
   //
   // Check Point B: "BufferSize" not be a multiple of NvRamAccessSize
   //
   StatusBuf[2] = SnpInterface->NvData (SnpInterface, TRUE, 0, (SnpInterface->Mode->NvRamAccessSize/2), Buffer);
- 
+
 
   //
   // Check Point C: "BufferSize" + "Offset" exceeds "NvRamSize"
   //
-  StatusBuf[3] = SnpInterface->NvData (SnpInterface, TRUE, 0, SnpInterface->Mode->NvRamSize+100, Buffer); 
+  StatusBuf[3] = SnpInterface->NvData (SnpInterface, TRUE, 0, SnpInterface->Mode->NvRamSize+100, Buffer);
 
 
-  if (StatusBuf[0] == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   StatusBuf[0]
-                   );
+
+  if ((StatusBuf[0] == EFI_NOT_STARTED) && (CheckPoint1State == EfiSimpleNetworkStopped)) {
+    AssertionType[0] = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((StatusBuf[0] == EFI_NOT_STARTED) && (CheckPoint1State == EfiSimpleNetworkStopped)) {
+    if (EFI_UNSUPPORTED == StatusBuf[0]) {
       AssertionType[0] = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType[0] = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType[0],
-                   gSimpleNetworkBBTestConformanceAssertionGuid020,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() when network interface not start.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[0]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType[0],
+                  gSimpleNetworkBBTestConformanceAssertionGuid020,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() when network interface not start.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[0]
+                  );
 
-  if (StatusBuf[1] == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   StatusBuf[1]
-                   );
+
+  if (StatusBuf[1] == EFI_INVALID_PARAMETER) {
+    AssertionType[1] = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (StatusBuf[1] == EFI_INVALID_PARAMETER) {
+    if (EFI_UNSUPPORTED == StatusBuf[1]) {
       AssertionType[1] = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType[1] = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType[1],
-                   gSimpleNetworkBBTestConformanceAssertionGuid021,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with Offset not be a multiple of NvRamAccessSize.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[1]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType[1],
+                  gSimpleNetworkBBTestConformanceAssertionGuid021,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with Offset not be a multiple of NvRamAccessSize.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[1]
+                  );
 
-  if (StatusBuf[2] == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   StatusBuf[2]
-                   );
+
+  if (StatusBuf[2] == EFI_INVALID_PARAMETER) {
+    AssertionType[2] = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (StatusBuf[2] == EFI_INVALID_PARAMETER) {
+    if (EFI_UNSUPPORTED == StatusBuf[2]) {
       AssertionType[2] = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType[2] = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType[2],
-                   gSimpleNetworkBBTestConformanceAssertionGuid022,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with BufferSize not be a multiple of NvRamAccessSize.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[2]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType[2],
+                  gSimpleNetworkBBTestConformanceAssertionGuid022,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with BufferSize not be a multiple of NvRamAccessSize.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[2]
+                  );
 
-  if (StatusBuf[3] == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   StatusBuf[3]
-                   );
+  if (StatusBuf[3] == EFI_INVALID_PARAMETER) {
+    AssertionType[3] = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (StatusBuf[3] == EFI_INVALID_PARAMETER) {
+    if (EFI_UNSUPPORTED == StatusBuf[3]) {
       AssertionType[3] = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType[3] = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType[3],
-                   gSimpleNetworkBBTestConformanceAssertionGuid023,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with BufferSize + Offset exceeds NvRamSize.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[3]
-                   );
   }
+  StandardLib->RecordAssertion (
+                StandardLib,
+                AssertionType[3],
+                gSimpleNetworkBBTestConformanceAssertionGuid023,
+                L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with BufferSize + Offset exceeds NvRamSize.",
+                L"%a:%d:Status - %r",
+                __FILE__,
+                (UINTN)__LINE__,
+                StatusBuf[3]
+                );
 
   //
   // Restore SNP Status
@@ -1552,8 +1478,8 @@ BBTestNVDataConformanceTest (
     if (EFI_ERROR(Status)) {
       return Status;
     }
-  } 
-  
+  }
+
   Status = gtBS->FreePool (Buffer);
   if (EFI_ERROR(Status)) {
     return Status;
@@ -1641,7 +1567,7 @@ BBTestGetStatusConformanceTest (
   } else {
     AssertionType[0] = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Assertion Point 5.11.2.2
   // Call GetStatus () function if network interface not initialized.
@@ -1667,7 +1593,7 @@ BBTestGetStatusConformanceTest (
   } else {
     AssertionType[1] = EFI_TEST_ASSERTION_FAILED;
   }
- 
+
 /*
   //
   // Assertion Point 5.11.2.3
@@ -1696,7 +1622,7 @@ BBTestGetStatusConformanceTest (
     AssertionType[2] = EFI_TEST_ASSERTION_FAILED;
   }
 */
-    
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[0],
@@ -1707,7 +1633,7 @@ BBTestGetStatusConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[0]
                  );
-  
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[1],
@@ -1718,7 +1644,7 @@ BBTestGetStatusConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[1]
                  );
-/*  
+/*
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[2],
@@ -1729,7 +1655,7 @@ BBTestGetStatusConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[2]
                  );
-*/                 
+*/
   //
   // Restore SNP State
   //
@@ -1902,7 +1828,7 @@ BBTestTransmitConformanceTest (
   } else {
     AssertionType[4] = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
 
   //
   // Check Point D: HeaderSize is nonzero and DestAddr is NULL.
@@ -1913,7 +1839,7 @@ BBTestTransmitConformanceTest (
   } else {
     AssertionType[5] = EFI_TEST_ASSERTION_FAILED;
   }
- 
+
 
   //
   // Check Point E: HeaderSize is nonzero and Protocol is NULL.
@@ -1935,7 +1861,7 @@ BBTestTransmitConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[0]
                  );
-   
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[1],
@@ -1957,7 +1883,7 @@ BBTestTransmitConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[2]
                  );
-  
+
    StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[3],
@@ -1978,7 +1904,7 @@ BBTestTransmitConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[4]
                  );
-  
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[5],
@@ -1989,7 +1915,7 @@ BBTestTransmitConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[5]
                  );
-   
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[6],
@@ -2119,7 +2045,7 @@ BBTestReceiveConformanceTest (
   } else {
     AssertionType[0] = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
 
   //
   // Assertion Point 5.13.2.2
@@ -2136,7 +2062,7 @@ BBTestReceiveConformanceTest (
   } else {
     AssertionType[1] = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Assertion Point 5.13.2.3
   // Call Receive() function with invalid parameters.
@@ -2171,7 +2097,7 @@ BBTestReceiveConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[0]
                  );
-  
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[1],
@@ -2208,22 +2134,22 @@ BBTestReceiveConformanceTest (
       return Status;
     }
   }
-  
+
 #if 0
   //
   // Assertion Point 5.13.2.4
   // No Packet Received in the Network Interface when Receive().
   //
   // We should disable the muticast and broadcast receive filters first. because
-  // some muticast or broadcast packets maybe on the LAN 
+  // some muticast or broadcast packets maybe on the LAN
   //
   Status = SnpInterface->ReceiveFilters (
-  	                       SnpInterface, 
-  	                       0, 
-  	                       EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST | EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST, 
-  	                       TRUE, 
-  	                       0, 
-  	                       NULL);
+                           SnpInterface,
+                           0,
+                           EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST | EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST,
+                           TRUE,
+                           0,
+                           NULL);
   if (EFI_ERROR(Status)) {
     StandardLib->RecordAssertion (
                    StandardLib,
@@ -2235,7 +2161,7 @@ BBTestReceiveConformanceTest (
                    (UINTN)__LINE__,
                    Status
                    );
-	return Status;
+    return Status;
   }
 
   Status = EFI_SUCCESS;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
@@ -2,15 +2,16 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2022, ARM Limited. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
-  which accompanies this distribution.  The full text of the license may be found at 
+  which accompanies this distribution.  The full text of the license may be found at
   http://opensource.org/licenses/bsd-license.php
- 
+
   THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
- 
+
 **/
 /*++
 
@@ -347,7 +348,8 @@ BBTestInitializeFunctionTest (
                  __FILE__,
                  (UINTN)__LINE__,
                  Status
-                 );
+                 );
+
 
   //
   // Restore SNP State
@@ -463,11 +465,14 @@ BBTestResetFunctionTest (
     return Status;
   }
 
-  Status = SnpInterface->Reset (SnpInterface, FALSE);
-
   AssertionType = EFI_TEST_ASSERTION_PASSED;
+  Status = SnpInterface->Reset (SnpInterface, FALSE);
   if (EFI_ERROR(Status)) {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
 
   if ((Mode.State != SnpInterface->Mode->State) ||
@@ -529,7 +534,11 @@ BBTestResetFunctionTest (
   if (Status == EFI_SUCCESS) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
   StandardLib->RecordAssertion (
                  StandardLib,
@@ -758,14 +767,16 @@ BBTestReceiveFilterFunctionTest (
 
     // Check point B. Disable Specified bit.
     Status = SnpInterface->ReceiveFilters (SnpInterface, 0, SupportedFilter, FALSE, 0, NULL);
-
     if ((Status == EFI_SUCCESS) &&
       ((SnpInterface->Mode->ReceiveFilterSetting & SupportedFilter) == 0)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      AssertionType = EFI_TEST_ASSERTION_FAILED;
+      if (EFI_UNSUPPORTED == Status) {
+        AssertionType = EFI_TEST_ASSERTION_PASSED;
+      } else {
+        AssertionType = EFI_TEST_ASSERTION_FAILED;
+      }
     }
-
     StandardLib->RecordAssertion (
                    StandardLib,
                    AssertionType,
@@ -780,14 +791,16 @@ BBTestReceiveFilterFunctionTest (
 
     // Check point A. Enable Specified bit.
     Status = SnpInterface->ReceiveFilters (SnpInterface, SupportedFilter, 0, FALSE, 0, NULL);
-
     if ((Status == EFI_SUCCESS) &&
       ((SnpInterface->Mode->ReceiveFilterSetting & SupportedFilter) != 0)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      AssertionType = EFI_TEST_ASSERTION_FAILED;
+      if (EFI_UNSUPPORTED == Status) {
+        AssertionType = EFI_TEST_ASSERTION_PASSED;
+      } else {
+        AssertionType = EFI_TEST_ASSERTION_FAILED;
+      }
     }
-
     StandardLib->RecordAssertion (
                    StandardLib,
                    AssertionType,
@@ -802,14 +815,16 @@ BBTestReceiveFilterFunctionTest (
 
     // Check point C. Enable and Disable Specified bit together.
     Status = SnpInterface->ReceiveFilters (SnpInterface, SupportedFilter, SupportedFilter, FALSE, 0, NULL);
-
     if ((Status == EFI_SUCCESS) &&
       ((SnpInterface->Mode->ReceiveFilterSetting & SupportedFilter) == 0)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      AssertionType = EFI_TEST_ASSERTION_FAILED;
+      if (EFI_UNSUPPORTED == Status) {
+        AssertionType = EFI_TEST_ASSERTION_PASSED;
+      } else {
+        AssertionType = EFI_TEST_ASSERTION_FAILED;
+      }
     }
-
     StandardLib->RecordAssertion (
                    StandardLib,
                    AssertionType,
@@ -844,9 +859,12 @@ BBTestReceiveFilterFunctionTest (
     } else if ((Status == EFI_INVALID_PARAMETER) && (SnpInterface->Mode->MaxMCastFilterCount == 0)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      AssertionType = EFI_TEST_ASSERTION_FAILED;
+      if (EFI_UNSUPPORTED == Status) {
+        AssertionType = EFI_TEST_ASSERTION_PASSED;
+      } else {
+        AssertionType = EFI_TEST_ASSERTION_FAILED;
+      }
     }
-
     StandardLib->RecordAssertion (
                    StandardLib,
                    AssertionType,
@@ -871,15 +889,17 @@ BBTestReceiveFilterFunctionTest (
   //
 
   Status = SnpInterface->ReceiveFilters (SnpInterface, 0, 0, TRUE, 0, NULL);
-
   if ((Status == EFI_SUCCESS) &&
       (SnpInterface->Mode->State == EfiSimpleNetworkInitialized) &&
       (SnpInterface->Mode->MCastFilterCount == 0)) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
-
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType,
@@ -1012,59 +1032,49 @@ BBTestStationAddressFunctionTest (
   //
   SnpInterface->StationAddress (SnpInterface, FALSE, &BackMacAddress);
 
-  if ((StatusBuf[0] == EFI_INVALID_PARAMETER) || (StatusBuf[0] == EFI_UNSUPPORTED)) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"StationAddress isn't supported, Status - %r\n",
-                   StatusBuf[0]
-                   );
+  if ((StatusBuf[0] == EFI_SUCCESS) &&
+      (!CheckPoint1)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((StatusBuf[0] == EFI_SUCCESS) &&
-        (!CheckPoint1)) {
+    if ((StatusBuf[0] == EFI_INVALID_PARAMETER) || (StatusBuf[0] == EFI_UNSUPPORTED)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid013,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke ReceiveFilters() to reset its MAC Address and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[0]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid013,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke ReceiveFilters() to reset its MAC Address and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[0]
+                  );
 
-  if ((StatusBuf[1] == EFI_INVALID_PARAMETER) || (StatusBuf[1] == EFI_UNSUPPORTED)) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"StationAddress isn't supported, Status - %r\n",
-                   StatusBuf[1]
-                   );
+
+  if ((StatusBuf[1] == EFI_SUCCESS) &&
+      (!CheckPoint2)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((StatusBuf[1] == EFI_SUCCESS) &&
-        (!CheckPoint2)) {
+    if ((StatusBuf[1] == EFI_INVALID_PARAMETER) || (StatusBuf[1] == EFI_UNSUPPORTED)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid014,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke ReceiveFilters() to modify its MAC Address and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[1]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid014,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke ReceiveFilters() to modify its MAC Address and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[1]
+                  );
+
 
   //
   // Restore SNP State
@@ -1181,11 +1191,11 @@ BBTestStatisticsFunctionTest (
       (!SctCompareMem (&StatisticsTable1, &StatisticsTable2, sizeof (EFI_NETWORK_STATISTICS)))) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
-  }
-
-  if (Status == EFI_UNSUPPORTED) {
-    AssertionType = EFI_TEST_ASSERTION_PASSED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
 
   StandardLib->RecordAssertion (
@@ -1218,11 +1228,11 @@ BBTestStatisticsFunctionTest (
       (!SctCompareMem (&StatisticsTable1, &StatisticsTable2, sizeof (EFI_NETWORK_STATISTICS)))) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
-  }
-
-  if (Status == EFI_UNSUPPORTED) {
-    AssertionType = EFI_TEST_ASSERTION_PASSED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
 
   StandardLib->RecordAssertion (
@@ -1487,91 +1497,74 @@ BBTestNVDataFunctionTest (
   //Check Point A(0, n*NvRamAccessSize)
   SctSetMem (Buffer, SnpInterface->Mode->NvRamSize, 0x0);
   Status = SnpInterface->NvData (SnpInterface, TRUE, 0, SnpInterface->Mode->NvRamSize, Buffer);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_SUCCESS) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_SUCCESS) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid018,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read(0, n*NvRamAccessSize) and verify interface correctness within test case",
-                   L"%a:%d:Status - %r, NvRamSize - %d, NvRamAccessSize - %d",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status,
-                   (UINTN)SnpInterface->Mode->NvRamSize,
-                   (UINTN)SnpInterface->Mode->NvRamAccessSize
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid018,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read(0, n*NvRamAccessSize) and verify interface correctness within test case",
+                  L"%a:%d:Status - %r, NvRamSize - %d, NvRamAccessSize - %d",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status,
+                  (UINTN)SnpInterface->Mode->NvRamSize,
+                  (UINTN)SnpInterface->Mode->NvRamAccessSize
+                  );
 
   //Check Point B(NvRamAccessSize, (n-1)*NvRamAccessSize)
   SctSetMem (Buffer, SnpInterface->Mode->NvRamSize, 0x0);
   Status = SnpInterface->NvData (SnpInterface, TRUE, SnpInterface->Mode->NvRamAccessSize, (SnpInterface->Mode->NvRamSize - SnpInterface->Mode->NvRamAccessSize), Buffer);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_SUCCESS) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_SUCCESS) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid019,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read(NvRamAccessSize, (n-1)*NvRamAccessSize) and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid019,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read(NvRamAccessSize, (n-1)*NvRamAccessSize) and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
+
 
   //Check Point C((n-1)*NvRamAccessSize, NvRamAccessSize)
   SctSetMem (Buffer, SnpInterface->Mode->NvRamSize, 0x0);
   Status = SnpInterface->NvData (SnpInterface, TRUE, (SnpInterface->Mode->NvRamSize - SnpInterface->Mode->NvRamAccessSize), SnpInterface->Mode->NvRamAccessSize, Buffer);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_SUCCESS) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_SUCCESS) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid020,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read((n-1)*NvRamAccessSize, NvRamAccessSize) and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid020,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read((n-1)*NvRamAccessSize, NvRamAccessSize) and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Assertion Point 4.10.2.2
@@ -1599,31 +1592,26 @@ BBTestNVDataFunctionTest (
     goto End;
   }
 
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   Status
-                   );
+  if ((Status == EFI_SUCCESS) && (!SctCompareMem (Buffer, Buffer1, SnpInterface->Mode->NvRamSize))) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((Status == EFI_SUCCESS) && (!SctCompareMem (Buffer, Buffer1, SnpInterface->Mode->NvRamSize))) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid021,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to write and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid021,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to write and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
 End:
   //
@@ -2322,9 +2310,14 @@ BBTestReceiveFunctionTest (
                            NULL
                            );
   if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
-                   EFI_TEST_ASSERTION_FAILED,
+                   AssertionType,
                    gTestGenericFailureGuid,
                    L"EFI_SIMPLE_NETWORK_PROTOCOL.Receive - Enable ReceiveFilters",
                    L"%a:%d:Status - %r",

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/PxeBaseCode/BlackBoxTest/PxeBaseCodeBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/PxeBaseCode/BlackBoxTest/PxeBaseCodeBBTestFunction.c
@@ -2,15 +2,16 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2022, ARM Limited. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
-  which accompanies this distribution.  The full text of the license may be found at 
+  which accompanies this distribution.  The full text of the license may be found at
   http://opensource.org/licenses/bsd-license.php
- 
+
   THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
- 
+
 **/
 /*++
 
@@ -203,7 +204,7 @@ BBTestUdpReadFuncSrcPortFilter (
 
 /**
  *  Entrypoint for EFI_PXE_BASE_CODE_PROTOCOL.Start() Function Test.
- *  It is the new case to add IPv6 into the test scope. The original test case is switched off. 
+ *  It is the new case to add IPv6 into the test scope. The original test case is switched off.
  *  @param This a pointer of EFI_BB_TEST_PROTOCOL.
  *  @param ClientInterface a pointer to the interface to be tested.
  *  @param TestLevel test "thoroughness" control.
@@ -380,7 +381,7 @@ BBTestNewStartFunctionTest (
                      L"Mode->PxeBisReplyReceived - %s\r\n",
                      BcInterface->Mode->PxeBisReplyReceived ? L"TRUE" : L"FALSE"
                      );
-    }   
+    }
     if (BcInterface->Mode->IcmpErrorReceived != FALSE) {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
       StandardLib->RecordMessage (
@@ -605,7 +606,7 @@ BBTestNewStartFunctionTest (
         return Status;
       }
     }
-    
+
     //
     // Enable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface in IPv6
     //
@@ -627,8 +628,8 @@ BBTestNewStartFunctionTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    
-    
+
+
     if (AssertionType == EFI_TEST_ASSERTION_PASSED) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
       if (BcInterface->Mode->Started != TRUE) {
@@ -720,7 +721,7 @@ BBTestNewStartFunctionTest (
                        L"Mode->PxeBisReplyReceived - %s\r\n",
                        BcInterface->Mode->PxeBisReplyReceived ? L"TRUE" : L"FALSE"
                        );
-      }   
+      }
       if (BcInterface->Mode->IcmpErrorReceived != FALSE) {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
         StandardLib->RecordMessage (
@@ -797,7 +798,7 @@ BBTestNewStartFunctionTest (
                        L"IS_PXE_PACKET_ZEROED(Mode->ProxyOffer) - Fail\r\n"
                        );
       }
-    
+
       if (IS_PXE_PACKET_ZEROED(&BcInterface->Mode->PxeDiscover) == FALSE) {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
         StandardLib->RecordMessage (
@@ -944,13 +945,13 @@ BBTestNewStartFunctionTest (
                      );
     }
   }
-  
+
   return Status;
 }
 
 /**
  *  Entrypoint for EFI_PXE_BASE_CODE_PROTOCOL.Statistics() Function Test.
- *  It is the new case to add IPv6 into the test scope. The original test case is switched off. 
+ *  It is the new case to add IPv6 into the test scope. The original test case is switched off.
  *  @param This a pointer of EFI_BB_TEST_PROTOCOL.
  *  @param ClientInterface a pointer to the interface to be tested.
  *  @param TestLevel test "thoroughness" control.
@@ -974,7 +975,7 @@ BBTestNewSetIpFilterFunctionTest (
   UINT8                                  Index;
 
   Index = 0;
-  
+
   //
   // Get the Standard Library Interface
   //
@@ -1091,7 +1092,7 @@ BBTestNewSetIpFilterFunctionTest (
         return Status;
       }
     }
-    
+
     //
     // Enable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface in IPv6
     //
@@ -1109,16 +1110,16 @@ BBTestNewSetIpFilterFunctionTest (
                      );
       return Status;
     }
-    
+
     SctSetMem (&BcIpFilter, sizeof (BcIpFilter), 0);
     BcIpFilter.Filters = EFI_PXE_BASE_CODE_IP_FILTER_STATION_IP;
     BcIpFilter.IpCnt = 2;
-    
+
     for (Index = 0; Index < 16; Index++) {
       BcIpFilter.IpList[0].v6.Addr[Index] = Index;
       BcIpFilter.IpList[1].v6.Addr[Index] = 16 - Index;
     }
-    
+
     Status = BcInterface->SetIpFilter (BcInterface, &BcIpFilter);
     if (Status == EFI_SUCCESS) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
@@ -1135,7 +1136,7 @@ BBTestNewSetIpFilterFunctionTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    
+
     if (TRUE == IsIpFilterEqual (&BcIpFilter, &(BcInterface->Mode->IpFilter))){
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
@@ -1158,7 +1159,7 @@ BBTestNewSetIpFilterFunctionTest (
 
 /**
  *  Entrypoint for EFI_PXE_BASE_CODE_PROTOCOL.Stop() Function Test.
- *  It is the new case to add IPv6 into the test scope. The original test case is switched off. 
+ *  It is the new case to add IPv6 into the test scope. The original test case is switched off.
  *  @param This a pointer of EFI_BB_TEST_PROTOCOL.
  *  @param ClientInterface a pointer to the interface to be tested.
  *  @param TestLevel test "thoroughness" control.
@@ -1290,7 +1291,7 @@ BBTestNewStopFunctionTest (
                  __FILE__,
                  (UINTN)__LINE__,
                  Status
-                 );  
+                 );
 
   return Status;
 }
@@ -1607,8 +1608,8 @@ BBTestStartFunctionTest (
                    );
   }
   if  ((0 != BcInterface->Mode->IpFilter.Filters) || (0 != BcInterface->Mode->IpFilter.IpCnt)) {
-  	AssertionType = EFI_TEST_ASSERTION_FAILED;
-	StandardLib->RecordMessage (
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    StandardLib->RecordMessage (
                    StandardLib,
                    EFI_VERBOSE_LEVEL_DEFAULT,
                    L"The Mode->IpFilter.Filters or Mode->IpFilter.IpCnt field is not 0\r\n");
@@ -2025,14 +2026,14 @@ BBTestMtftpFunctionTest (
   )
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
-  EFI_TEST_PROFILE_LIBRARY_PROTOCOL    *ProfileLib;
+  EFI_TEST_PROFILE_LIBRARY_PROTOCOL     *ProfileLib;
   EFI_TEST_LOGGING_LIBRARY_PROTOCOL     *LoggingLib;
   EFI_INI_FILE_HANDLE                    FileHandle;
   EFI_STATUS                             Status;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   UINTN                                  FileSize;
-
+  EFI_TEST_ASSERTION                     AssertionType;
   //
   // Get support library (Standard Lib, Profile Lib, Logging Lib)
   //
@@ -2098,8 +2099,12 @@ BBTestMtftpFunctionTest (
   }
 
   Status = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  if (EFI_ERROR(Status))
-  {
+  if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
                    EFI_TEST_ASSERTION_FAILED,
@@ -2202,12 +2207,13 @@ BBTestUdpWriteFunctionTest (
   )
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
-  EFI_TEST_PROFILE_LIBRARY_PROTOCOL    *ProfileLib;
+  EFI_TEST_PROFILE_LIBRARY_PROTOCOL     *ProfileLib;
   EFI_TEST_LOGGING_LIBRARY_PROTOCOL     *LoggingLib;
   EFI_INI_FILE_HANDLE                    FileHandle;
   EFI_STATUS                             Status;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
+  EFI_TEST_ASSERTION                     AssertionType;
 
   //
   // Get the Standard Library Interface
@@ -2296,8 +2302,12 @@ BBTestUdpWriteFunctionTest (
   }
 
   Status = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  if (EFI_ERROR(Status))
-  {
+  if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
                    EFI_TEST_ASSERTION_FAILED,
@@ -2371,13 +2381,14 @@ BBTestUdpReadFunctionTest (
   )
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
-  EFI_TEST_PROFILE_LIBRARY_PROTOCOL    *ProfileLib;
+  EFI_TEST_PROFILE_LIBRARY_PROTOCOL     *ProfileLib;
   EFI_TEST_LOGGING_LIBRARY_PROTOCOL     *LoggingLib;
   EFI_INI_FILE_HANDLE                    FileHandle;
   EFI_STATUS                             Status;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
   EFI_PXE_BASE_CODE_IP_FILTER            BcIpFilter;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
+  EFI_TEST_ASSERTION                     AssertionType;
 
   //
   // Get the Support Library Interface
@@ -2473,8 +2484,12 @@ BBTestUdpReadFunctionTest (
   }
 
   Status = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  if (EFI_ERROR(Status))
-  {
+  if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
                    EFI_TEST_ASSERTION_FAILED,
@@ -2644,7 +2659,7 @@ BBTestArpFunctionTest (
   )
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
-  EFI_TEST_PROFILE_LIBRARY_PROTOCOL    *ProfileLib;
+  EFI_TEST_PROFILE_LIBRARY_PROTOCOL     *ProfileLib;
   EFI_TEST_LOGGING_LIBRARY_PROTOCOL     *LoggingLib;
   EFI_INI_FILE_HANDLE                    FileHandle;
   EFI_STATUS                             Status;
@@ -2755,8 +2770,12 @@ BBTestArpFunctionTest (
   }
 
   Status = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  if (EFI_ERROR(Status))
-  {
+  if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
                    EFI_TEST_ASSERTION_FAILED,

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestConformance.c
@@ -2,15 +2,16 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2022, ARM Limited. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
-  which accompanies this distribution.  The full text of the license may be found at 
+  which accompanies this distribution.  The full text of the license may be found at
   http://opensource.org/licenses/bsd-license.php
- 
+
   THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
- 
+
 **/
 /*++
 
@@ -100,7 +101,7 @@ BBTestStartConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // restore SNP status
   //
@@ -108,7 +109,7 @@ BBTestStartConformanceTest (
     Status1 = SnpInterface->Initialize(SnpInterface, 0, 0);
     if (EFI_ERROR(Status1)) {
       return Status1;
-    }  
+    }
   }
 
   StandardLib->RecordAssertion (
@@ -206,7 +207,7 @@ BBTestStopConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Restore SNP status
   //
@@ -311,10 +312,10 @@ BBTestInitializeConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Restore SNP status
-  // 
+  //
   if (State1 != EfiSimpleNetworkStopped) {
     Status1 = SnpInterface->Start (SnpInterface);
     if (EFI_ERROR(Status1)) {
@@ -332,7 +333,7 @@ BBTestInitializeConformanceTest (
     }
   }
 
-  
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType,
@@ -416,16 +417,19 @@ BBTestResetConformanceTest (
   // Call Reset() function when network interface not start.
   //
   Status = SnpInterface->Reset (SnpInterface, FALSE);
-
   if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
-  
+
   //
   // Restore SNP status
-  // 
+  //
   if (State1 != EfiSimpleNetworkStopped) {
     Status1 = SnpInterface->Start (SnpInterface);
     if (EFI_ERROR(Status1)) {
@@ -450,7 +454,7 @@ BBTestResetConformanceTest (
                  (UINTN)__LINE__,
                  Status
                  );
- 
+
 
   return EFI_SUCCESS;
 }
@@ -528,7 +532,7 @@ BBTestShutdownConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Restore SNP status
   //
@@ -626,31 +630,26 @@ BBTestReceiveFilterConformanceTest (
   // Call ReceiveFilters() function if network interface not start.
   //
   Status = SnpInterface->ReceiveFilters (SnpInterface, 0, 0, FALSE, 0, NULL);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"ReceiveFilters isn't supported, Status - %r\n",
-                   Status
-                   );
+  if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid006,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() when network interface not start.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid006,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() when network interface not start.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Assertion Point 5.6.2.2
@@ -662,31 +661,26 @@ BBTestReceiveFilterConformanceTest (
   }
 
   Status = SnpInterface->ReceiveFilters (SnpInterface, 0, 0, FALSE, 0, NULL);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"ReceiveFilters isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_DEVICE_ERROR) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_DEVICE_ERROR) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid007,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() when network interface not initialized.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid007,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() when network interface not initialized.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Assertion Point 5.6.2.3
@@ -701,31 +695,26 @@ BBTestReceiveFilterConformanceTest (
   //  Call ReceiveFilters with invalide Enable
   //
   Status = SnpInterface->ReceiveFilters (SnpInterface, ~(SnpInterface->Mode->ReceiveFilterMask), 0, FALSE, 0, NULL);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"ReceiveFilters isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_INVALID_PARAMETER) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid008,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid Enable.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid008,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid Enable.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   //  Call ReceiveFilters with invalide MCastFilterCnt
@@ -740,85 +729,70 @@ BBTestReceiveFilterConformanceTest (
     MAC.Addr[5] = 0x02;
 
     Status = SnpInterface->ReceiveFilters (SnpInterface, EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST, 0, FALSE, SnpInterface->Mode->MaxMCastFilterCount + 1, &MAC);
-    if (Status == EFI_UNSUPPORTED) {
-      StandardLib->RecordMessage(
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_QUIET,
-                     L"ReceiveFilters isn't supported, Status - %r\n",
-                     Status
-                     );
+    if (Status == EFI_INVALID_PARAMETER) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      if (Status == EFI_INVALID_PARAMETER) {
+      if (EFI_UNSUPPORTED == Status) {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
       } else {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
       }
-
-      StandardLib->RecordAssertion (
-                     StandardLib,
-                     AssertionType,
-                     gSimpleNetworkBBTestConformanceAssertionGuid009,
-                     L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid MCastFilterCnt is greater than Snp->Mode->MaxMCastFilterCount.",
-                     L"%a:%d:Status - %r",
-                     __FILE__,
-                     (UINTN)__LINE__,
-                     Status
-                     );
     }
+
+    StandardLib->RecordAssertion (
+                    StandardLib,
+                    AssertionType,
+                    gSimpleNetworkBBTestConformanceAssertionGuid009,
+                    L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid MCastFilterCnt is greater than Snp->Mode->MaxMCastFilterCount.",
+                    L"%a:%d:Status - %r",
+                    __FILE__,
+                    (UINTN)__LINE__,
+                    Status
+                    );
 
     Status = SnpInterface->ReceiveFilters (SnpInterface, EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST, 0, FALSE, 0, &MAC);
-    if (Status == EFI_UNSUPPORTED) {
-      StandardLib->RecordMessage(
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_QUIET,
-                     L"ReceiveFilters isn't supported, Status - %r\n",
-                     Status
-                     );
+    if (Status == EFI_INVALID_PARAMETER) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      if (Status == EFI_INVALID_PARAMETER) {
+      if (EFI_UNSUPPORTED == Status) {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
       } else {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
       }
-
-      StandardLib->RecordAssertion (
-                     StandardLib,
-                     AssertionType,
-                     gSimpleNetworkBBTestConformanceAssertionGuid043,
-                     L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid MCastFilterCnt is 0.",
-                     L"%a:%d:Status - %r",
-                     __FILE__,
-                     (UINTN)__LINE__,
-                     Status
-                     );
     }
+
+    StandardLib->RecordAssertion (
+                    StandardLib,
+                    AssertionType,
+                    gSimpleNetworkBBTestConformanceAssertionGuid043,
+                    L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with invalid MCastFilterCnt is 0.",
+                    L"%a:%d:Status - %r",
+                    __FILE__,
+                    (UINTN)__LINE__,
+                    Status
+                    );
 
     Status = SnpInterface->ReceiveFilters (SnpInterface, EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST, 0, FALSE, 1, NULL);
-    if (Status == EFI_UNSUPPORTED) {
-      StandardLib->RecordMessage(
-                     StandardLib,
-                     EFI_VERBOSE_LEVEL_QUIET,
-                     L"ReceiveFilters isn't supported, Status - %r\n",
-                     Status
-                     );
+    if (Status == EFI_INVALID_PARAMETER) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      if (Status == EFI_INVALID_PARAMETER) {
+      if (EFI_UNSUPPORTED == Status) {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
       } else {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
       }
-
-      StandardLib->RecordAssertion (
-                       StandardLib,
-                       AssertionType,
-                       gSimpleNetworkBBTestConformanceAssertionGuid010,
-                       L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with MCastFilterCnt not match MCastFilter.",
-                       L"%a:%d:Status - %r",
-                       __FILE__,
-                       (UINTN)__LINE__,
-                       Status
-                       );
     }
+
+    StandardLib->RecordAssertion (
+                      StandardLib,
+                      AssertionType,
+                      gSimpleNetworkBBTestConformanceAssertionGuid010,
+                      L"EFI_SIMPLE_NETWORK_PROTOCOL.ReceiveFilters - Invoke ReceiveFilters() with MCastFilterCnt not match MCastFilter.",
+                      L"%a:%d:Status - %r",
+                      __FILE__,
+                      (UINTN)__LINE__,
+                      Status
+                      );
   }
 
   //
@@ -912,7 +886,7 @@ BBTestStationAddressConformanceTest (
   // save current snp state
   //
   State2 = SnpInterface->Mode->State;
-  
+
   //
   // Assertion Point 5.7.2.2
   // Call StationAddress() function if network interface not initialized.
@@ -923,71 +897,59 @@ BBTestStationAddressConformanceTest (
   }
 
   StatusBuf[1] = SnpInterface->StationAddress (SnpInterface, TRUE, NULL);
-  
+
   //
   // Restore SNP Status
   //
   if (State1 == EfiSimpleNetworkInitialized) {
-    Status = SnpInterface->Initialize(SnpInterface, 0, 0); 
+    Status = SnpInterface->Initialize(SnpInterface, 0, 0);
     if (EFI_ERROR(Status)){
       return Status;
     }
   }
-  
-  if ((StatusBuf[0] == EFI_INVALID_PARAMETER) || (StatusBuf[0] == EFI_UNSUPPORTED)) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"StationAddress isn't supported, Status - %r\n",
-                   StatusBuf[0]
-                   );
+
+  if ((StatusBuf[0] == EFI_NOT_STARTED) && (State2 == EfiSimpleNetworkStopped)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((StatusBuf[0] == EFI_NOT_STARTED) && (State2 == EfiSimpleNetworkStopped)) {
+    if ((StatusBuf[0] == EFI_INVALID_PARAMETER) || (StatusBuf[0] == EFI_UNSUPPORTED)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid011,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke StationAddress() when network interface not start.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[0]
-                   );
   }
-  
-  if ((StatusBuf[1] == EFI_INVALID_PARAMETER) || (StatusBuf[1] == EFI_UNSUPPORTED)) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"StationAddress isn't supported, Status - %r\n",
-                   StatusBuf[1]
-                   );
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid011,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke StationAddress() when network interface not start.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[0]
+                  );
+
+  if (StatusBuf[1] == EFI_DEVICE_ERROR) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (StatusBuf[1] == EFI_DEVICE_ERROR) {
+    if ((StatusBuf[1] == EFI_INVALID_PARAMETER) || (StatusBuf[1] == EFI_UNSUPPORTED)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid012,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke StationAddress() when network interface not initialized.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[1]
-                   );
   }
-  
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid012,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke StationAddress() when network interface not initialized.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[1]
+                  );
+
   if (State1 == EfiSimpleNetworkStopped) {
-    Status = SnpInterface->Stop (SnpInterface); 
+    Status = SnpInterface->Stop (SnpInterface);
     if (EFI_ERROR(Status)){
       return Status;
     }
@@ -1067,30 +1029,25 @@ BBTestStatisticsConformanceTest (
   // Call Statistics() function while network interface is not started.
   //
   Status = SnpInterface->Statistics (SnpInterface, FALSE, &StatisticsSize, &StatisticsTable);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"Statistics isn't supported, Status - %r\n",
-                   Status
-                   );
+  if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((Status == EFI_NOT_STARTED) && (SnpInterface->Mode->State == EfiSimpleNetworkStopped)) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid014,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() while network interface not started.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid014,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() while network interface not started.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Assertion Point 5.8.2.2
@@ -1102,30 +1059,25 @@ BBTestStatisticsConformanceTest (
   }
 
   Status = SnpInterface->Statistics (SnpInterface, FALSE, &StatisticsSize, &StatisticsTable);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"Statistics isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_DEVICE_ERROR) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_DEVICE_ERROR) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid015,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() while network interface is not initialized.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid015,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() while network interface is not initialized.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Assertion Point 5.8.2.3
@@ -1143,30 +1095,25 @@ BBTestStatisticsConformanceTest (
   StatisticsSize = 0;
 
   Status = SnpInterface->Statistics (SnpInterface, FALSE, &StatisticsSize, &StatisticsTable);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"Statistics isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_BUFFER_TOO_SMALL) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_BUFFER_TOO_SMALL) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestConformanceAssertionGuid017,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() with small buffer.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestConformanceAssertionGuid017,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.Statistics - Invoke Statistics() with small buffer.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Restore SNP State
@@ -1182,7 +1129,7 @@ BBTestStatisticsConformanceTest (
       return Status;
     }
   }
-  
+
   return EFI_SUCCESS;
 }
 
@@ -1267,7 +1214,7 @@ BBTestMCastIpToMacConformanceTest (
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Restore SNP status
   //
@@ -1405,7 +1352,7 @@ BBTestNVDataConformanceTest (
 
   StatusBuf[0] = SnpInterface->NvData (SnpInterface, TRUE, 0, SnpInterface->Mode->NvRamAccessSize, Buffer);
   CheckPoint1State = SnpInterface->Mode->State;
-  
+
 
   //
   // Assertion Point 5.10.2.2
@@ -1425,119 +1372,99 @@ BBTestNVDataConformanceTest (
   // Check Point A: "Offset" not be a multiple of NvRamAccessSize
   //
   StatusBuf[1] = SnpInterface->NvData (SnpInterface, TRUE, (SnpInterface->Mode->NvRamAccessSize/2), SnpInterface->Mode->NvRamAccessSize, Buffer);
- 
+
 
   //
   // Check Point B: "BufferSize" not be a multiple of NvRamAccessSize
   //
   StatusBuf[2] = SnpInterface->NvData (SnpInterface, TRUE, 0, (SnpInterface->Mode->NvRamAccessSize/2), Buffer);
- 
+
 
   //
   // Check Point C: "BufferSize" + "Offset" exceeds "NvRamSize"
   //
-  StatusBuf[3] = SnpInterface->NvData (SnpInterface, TRUE, 0, SnpInterface->Mode->NvRamSize+100, Buffer); 
+  StatusBuf[3] = SnpInterface->NvData (SnpInterface, TRUE, 0, SnpInterface->Mode->NvRamSize+100, Buffer);
 
 
-  if (StatusBuf[0] == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   StatusBuf[0]
-                   );
+  if ((StatusBuf[0] == EFI_NOT_STARTED) && (CheckPoint1State == EfiSimpleNetworkStopped)) {
+    AssertionType[0] = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((StatusBuf[0] == EFI_NOT_STARTED) && (CheckPoint1State == EfiSimpleNetworkStopped)) {
+    if (EFI_UNSUPPORTED == StatusBuf[0]) {
       AssertionType[0] = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType[0] = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType[0],
-                   gSimpleNetworkBBTestConformanceAssertionGuid020,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() when network interface not start.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[0]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType[0],
+                  gSimpleNetworkBBTestConformanceAssertionGuid020,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() when network interface not start.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[0]
+                  );
 
-  if (StatusBuf[1] == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   StatusBuf[1]
-                   );
+  if (StatusBuf[1] == EFI_INVALID_PARAMETER) {
+    AssertionType[1] = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (StatusBuf[1] == EFI_INVALID_PARAMETER) {
+    if (EFI_UNSUPPORTED == StatusBuf[1]) {
       AssertionType[1] = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType[1] = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType[1],
-                   gSimpleNetworkBBTestConformanceAssertionGuid021,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with Offset not be a multiple of NvRamAccessSize.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[1]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType[1],
+                  gSimpleNetworkBBTestConformanceAssertionGuid021,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with Offset not be a multiple of NvRamAccessSize.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[1]
+                  );
 
-  if (StatusBuf[2] == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   StatusBuf[2]
-                   );
+  if (StatusBuf[2] == EFI_INVALID_PARAMETER) {
+    AssertionType[2] = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (StatusBuf[2] == EFI_INVALID_PARAMETER) {
+    if (EFI_UNSUPPORTED == StatusBuf[2]) {
       AssertionType[2] = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType[2] = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType[2],
-                   gSimpleNetworkBBTestConformanceAssertionGuid022,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with BufferSize not be a multiple of NvRamAccessSize.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[2]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType[2],
+                  gSimpleNetworkBBTestConformanceAssertionGuid022,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with BufferSize not be a multiple of NvRamAccessSize.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[2]
+                  );
 
-  if (StatusBuf[3] == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   StatusBuf[3]
-                   );
+  if (StatusBuf[3] == EFI_INVALID_PARAMETER) {
+    AssertionType[3] = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (StatusBuf[3] == EFI_INVALID_PARAMETER) {
+    if (EFI_UNSUPPORTED == StatusBuf[3]) {
       AssertionType[3] = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType[3] = EFI_TEST_ASSERTION_FAILED;
     }
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType[3],
-                   gSimpleNetworkBBTestConformanceAssertionGuid023,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with BufferSize + Offset exceeds NvRamSize.",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[3]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType[3],
+                  gSimpleNetworkBBTestConformanceAssertionGuid023,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() with BufferSize + Offset exceeds NvRamSize.",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[3]
+                  );
 
   //
   // Restore SNP Status
@@ -1552,8 +1479,8 @@ BBTestNVDataConformanceTest (
     if (EFI_ERROR(Status)) {
       return Status;
     }
-  } 
-  
+  }
+
   Status = gtBS->FreePool (Buffer);
   if (EFI_ERROR(Status)) {
     return Status;
@@ -1641,7 +1568,7 @@ BBTestGetStatusConformanceTest (
   } else {
     AssertionType[0] = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Assertion Point 5.11.2.2
   // Call GetStatus () function if network interface not initialized.
@@ -1667,7 +1594,7 @@ BBTestGetStatusConformanceTest (
   } else {
     AssertionType[1] = EFI_TEST_ASSERTION_FAILED;
   }
- 
+
 /*
   //
   // Assertion Point 5.11.2.3
@@ -1696,7 +1623,7 @@ BBTestGetStatusConformanceTest (
     AssertionType[2] = EFI_TEST_ASSERTION_FAILED;
   }
 */
-    
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[0],
@@ -1707,7 +1634,7 @@ BBTestGetStatusConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[0]
                  );
-  
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[1],
@@ -1718,7 +1645,7 @@ BBTestGetStatusConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[1]
                  );
-/*  
+/*
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[2],
@@ -1729,7 +1656,7 @@ BBTestGetStatusConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[2]
                  );
-*/                 
+*/
   //
   // Restore SNP State
   //
@@ -1902,7 +1829,7 @@ BBTestTransmitConformanceTest (
   } else {
     AssertionType[4] = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
 
   //
   // Check Point D: HeaderSize is nonzero and DestAddr is NULL.
@@ -1913,7 +1840,7 @@ BBTestTransmitConformanceTest (
   } else {
     AssertionType[5] = EFI_TEST_ASSERTION_FAILED;
   }
- 
+
 
   //
   // Check Point E: HeaderSize is nonzero and Protocol is NULL.
@@ -1935,7 +1862,7 @@ BBTestTransmitConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[0]
                  );
-   
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[1],
@@ -1957,7 +1884,7 @@ BBTestTransmitConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[2]
                  );
-  
+
    StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[3],
@@ -1978,7 +1905,7 @@ BBTestTransmitConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[4]
                  );
-  
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[5],
@@ -1989,7 +1916,7 @@ BBTestTransmitConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[5]
                  );
-   
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[6],
@@ -2119,7 +2046,7 @@ BBTestReceiveConformanceTest (
   } else {
     AssertionType[0] = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
 
   //
   // Assertion Point 5.13.2.2
@@ -2136,7 +2063,7 @@ BBTestReceiveConformanceTest (
   } else {
     AssertionType[1] = EFI_TEST_ASSERTION_FAILED;
   }
-  
+
   //
   // Assertion Point 5.13.2.3
   // Call Receive() function with invalid parameters.
@@ -2171,7 +2098,7 @@ BBTestReceiveConformanceTest (
                  (UINTN)__LINE__,
                  StatusBuf[0]
                  );
-  
+
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType[1],
@@ -2208,22 +2135,22 @@ BBTestReceiveConformanceTest (
       return Status;
     }
   }
-  
+
 #if 0
   //
   // Assertion Point 5.13.2.4
   // No Packet Received in the Network Interface when Receive().
   //
   // We should disable the muticast and broadcast receive filters first. because
-  // some muticast or broadcast packets maybe on the LAN 
+  // some muticast or broadcast packets maybe on the LAN
   //
   Status = SnpInterface->ReceiveFilters (
-  	                       SnpInterface, 
-  	                       0, 
-  	                       EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST | EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST, 
-  	                       TRUE, 
-  	                       0, 
-  	                       NULL);
+                           SnpInterface,
+                           0,
+                           EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST | EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST,
+                           TRUE,
+                           0,
+                           NULL);
   if (EFI_ERROR(Status)) {
     StandardLib->RecordAssertion (
                    StandardLib,
@@ -2235,7 +2162,7 @@ BBTestReceiveConformanceTest (
                    (UINTN)__LINE__,
                    Status
                    );
-	return Status;
+    return Status;
   }
 
   Status = EFI_SUCCESS;

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
@@ -2,15 +2,16 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2022, ARM Limited. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
-  which accompanies this distribution.  The full text of the license may be found at 
+  which accompanies this distribution.  The full text of the license may be found at
   http://opensource.org/licenses/bsd-license.php
- 
+
   THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
   WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
- 
+
 **/
 /*++
 
@@ -463,11 +464,14 @@ BBTestResetFunctionTest (
     return Status;
   }
 
-  Status = SnpInterface->Reset (SnpInterface, FALSE);
-
   AssertionType = EFI_TEST_ASSERTION_PASSED;
+  Status = SnpInterface->Reset (SnpInterface, FALSE);
   if (EFI_ERROR(Status)) {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
 
   if ((Mode.State != SnpInterface->Mode->State) ||
@@ -529,7 +533,11 @@ BBTestResetFunctionTest (
   if (Status == EFI_SUCCESS) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
   StandardLib->RecordAssertion (
                  StandardLib,
@@ -758,14 +766,16 @@ BBTestReceiveFilterFunctionTest (
 
     // Check point B. Disable Specified bit.
     Status = SnpInterface->ReceiveFilters (SnpInterface, 0, SupportedFilter, FALSE, 0, NULL);
-
     if ((Status == EFI_SUCCESS) &&
       ((SnpInterface->Mode->ReceiveFilterSetting & SupportedFilter) == 0)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      AssertionType = EFI_TEST_ASSERTION_FAILED;
+      if (EFI_UNSUPPORTED == Status) {
+        AssertionType = EFI_TEST_ASSERTION_PASSED;
+      } else {
+        AssertionType = EFI_TEST_ASSERTION_FAILED;
+      }
     }
-
     StandardLib->RecordAssertion (
                    StandardLib,
                    AssertionType,
@@ -780,14 +790,16 @@ BBTestReceiveFilterFunctionTest (
 
     // Check point A. Enable Specified bit.
     Status = SnpInterface->ReceiveFilters (SnpInterface, SupportedFilter, 0, FALSE, 0, NULL);
-
     if ((Status == EFI_SUCCESS) &&
       ((SnpInterface->Mode->ReceiveFilterSetting & SupportedFilter) != 0)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      AssertionType = EFI_TEST_ASSERTION_FAILED;
+      if (EFI_UNSUPPORTED == Status) {
+        AssertionType = EFI_TEST_ASSERTION_PASSED;
+      } else {
+        AssertionType = EFI_TEST_ASSERTION_FAILED;
+      }
     }
-
     StandardLib->RecordAssertion (
                    StandardLib,
                    AssertionType,
@@ -802,14 +814,16 @@ BBTestReceiveFilterFunctionTest (
 
     // Check point C. Enable and Disable Specified bit together.
     Status = SnpInterface->ReceiveFilters (SnpInterface, SupportedFilter, SupportedFilter, FALSE, 0, NULL);
-
     if ((Status == EFI_SUCCESS) &&
       ((SnpInterface->Mode->ReceiveFilterSetting & SupportedFilter) == 0)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      AssertionType = EFI_TEST_ASSERTION_FAILED;
+      if (EFI_UNSUPPORTED == Status) {
+        AssertionType = EFI_TEST_ASSERTION_PASSED;
+      } else {
+        AssertionType = EFI_TEST_ASSERTION_FAILED;
+      }
     }
-
     StandardLib->RecordAssertion (
                    StandardLib,
                    AssertionType,
@@ -844,9 +858,12 @@ BBTestReceiveFilterFunctionTest (
     } else if ((Status == EFI_INVALID_PARAMETER) && (SnpInterface->Mode->MaxMCastFilterCount == 0)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
-      AssertionType = EFI_TEST_ASSERTION_FAILED;
+      if (EFI_UNSUPPORTED == Status) {
+        AssertionType = EFI_TEST_ASSERTION_PASSED;
+      } else {
+        AssertionType = EFI_TEST_ASSERTION_FAILED;
+      }
     }
-
     StandardLib->RecordAssertion (
                    StandardLib,
                    AssertionType,
@@ -869,17 +886,18 @@ BBTestReceiveFilterFunctionTest (
   // Assertion Point 4.6.2.3
   // Reset multicast receive filters list.
   //
-
   Status = SnpInterface->ReceiveFilters (SnpInterface, 0, 0, TRUE, 0, NULL);
-
   if ((Status == EFI_SUCCESS) &&
       (SnpInterface->Mode->State == EfiSimpleNetworkInitialized) &&
       (SnpInterface->Mode->MCastFilterCount == 0)) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
-
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType,
@@ -1012,59 +1030,47 @@ BBTestStationAddressFunctionTest (
   //
   SnpInterface->StationAddress (SnpInterface, FALSE, &BackMacAddress);
 
-  if ((StatusBuf[0] == EFI_INVALID_PARAMETER) || (StatusBuf[0] == EFI_UNSUPPORTED)) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"StationAddress isn't supported, Status - %r\n",
-                   StatusBuf[0]
-                   );
+  if ((StatusBuf[0] == EFI_SUCCESS) &&
+      (!CheckPoint1)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((StatusBuf[0] == EFI_SUCCESS) &&
-        (!CheckPoint1)) {
+    if ((StatusBuf[0] == EFI_INVALID_PARAMETER) || (StatusBuf[0] == EFI_UNSUPPORTED)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid013,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke ReceiveFilters() to reset its MAC Address and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[0]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid013,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke ReceiveFilters() to reset its MAC Address and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[0]
+                  );
 
-  if ((StatusBuf[1] == EFI_INVALID_PARAMETER) || (StatusBuf[1] == EFI_UNSUPPORTED)) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"StationAddress isn't supported, Status - %r\n",
-                   StatusBuf[1]
-                   );
+  if ((StatusBuf[1] == EFI_SUCCESS) &&
+      (!CheckPoint2)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((StatusBuf[1] == EFI_SUCCESS) &&
-        (!CheckPoint2)) {
+    if ((StatusBuf[1] == EFI_INVALID_PARAMETER) || (StatusBuf[1] == EFI_UNSUPPORTED)) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid014,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke ReceiveFilters() to modify its MAC Address and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   StatusBuf[1]
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid014,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.StationAddress - Invoke ReceiveFilters() to modify its MAC Address and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  StatusBuf[1]
+                  );
 
   //
   // Restore SNP State
@@ -1181,13 +1187,12 @@ BBTestStatisticsFunctionTest (
       (!SctCompareMem (&StatisticsTable1, &StatisticsTable2, sizeof (EFI_NETWORK_STATISTICS)))) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
-
-  if (Status == EFI_UNSUPPORTED) {
-    AssertionType = EFI_TEST_ASSERTION_PASSED;
-  }
-
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType,
@@ -1218,13 +1223,12 @@ BBTestStatisticsFunctionTest (
       (!SctCompareMem (&StatisticsTable1, &StatisticsTable2, sizeof (EFI_NETWORK_STATISTICS)))) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    AssertionType = EFI_TEST_ASSERTION_FAILED;
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
   }
-
-  if (Status == EFI_UNSUPPORTED) {
-    AssertionType = EFI_TEST_ASSERTION_PASSED;
-  }
-
   StandardLib->RecordAssertion (
                  StandardLib,
                  AssertionType,
@@ -1487,91 +1491,75 @@ BBTestNVDataFunctionTest (
   //Check Point A(0, n*NvRamAccessSize)
   SctSetMem (Buffer, SnpInterface->Mode->NvRamSize, 0x0);
   Status = SnpInterface->NvData (SnpInterface, TRUE, 0, SnpInterface->Mode->NvRamSize, Buffer);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_SUCCESS) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_SUCCESS) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid018,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read(0, n*NvRamAccessSize) and verify interface correctness within test case",
-                   L"%a:%d:Status - %r, NvRamSize - %d, NvRamAccessSize - %d",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status,
-                   (UINTN)SnpInterface->Mode->NvRamSize,
-                   (UINTN)SnpInterface->Mode->NvRamAccessSize
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid018,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read(0, n*NvRamAccessSize) and verify interface correctness within test case",
+                  L"%a:%d:Status - %r, NvRamSize - %d, NvRamAccessSize - %d",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status,
+                  (UINTN)SnpInterface->Mode->NvRamSize,
+                  (UINTN)SnpInterface->Mode->NvRamAccessSize
+                  );
 
   //Check Point B(NvRamAccessSize, (n-1)*NvRamAccessSize)
   SctSetMem (Buffer, SnpInterface->Mode->NvRamSize, 0x0);
   Status = SnpInterface->NvData (SnpInterface, TRUE, SnpInterface->Mode->NvRamAccessSize, (SnpInterface->Mode->NvRamSize - SnpInterface->Mode->NvRamAccessSize), Buffer);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_SUCCESS) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_SUCCESS) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid019,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read(NvRamAccessSize, (n-1)*NvRamAccessSize) and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid019,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read(NvRamAccessSize, (n-1)*NvRamAccessSize) and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //Check Point C((n-1)*NvRamAccessSize, NvRamAccessSize)
   SctSetMem (Buffer, SnpInterface->Mode->NvRamSize, 0x0);
   Status = SnpInterface->NvData (SnpInterface, TRUE, (SnpInterface->Mode->NvRamSize - SnpInterface->Mode->NvRamAccessSize), SnpInterface->Mode->NvRamAccessSize, Buffer);
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   Status
-                   );
+  if (Status == EFI_SUCCESS) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if (Status == EFI_SUCCESS) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid020,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read((n-1)*NvRamAccessSize, NvRamAccessSize) and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid020,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to read((n-1)*NvRamAccessSize, NvRamAccessSize) and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
   //
   // Assertion Point 4.10.2.2
@@ -1599,31 +1587,25 @@ BBTestNVDataFunctionTest (
     goto End;
   }
 
-  if (Status == EFI_UNSUPPORTED) {
-    StandardLib->RecordMessage(
-                   StandardLib,
-                   EFI_VERBOSE_LEVEL_QUIET,
-                   L"NvData isn't supported, Status - %r\n",
-                   Status
-                   );
+  if ((Status == EFI_SUCCESS) && (!SctCompareMem (Buffer, Buffer1, SnpInterface->Mode->NvRamSize))) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
   } else {
-    if ((Status == EFI_SUCCESS) && (!SctCompareMem (Buffer, Buffer1, SnpInterface->Mode->NvRamSize))) {
+    if (EFI_UNSUPPORTED == Status) {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;
     }
-
-    StandardLib->RecordAssertion (
-                   StandardLib,
-                   AssertionType,
-                   gSimpleNetworkBBTestFunctionAssertionGuid021,
-                   L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to write and verify interface correctness within test case",
-                   L"%a:%d:Status - %r",
-                   __FILE__,
-                   (UINTN)__LINE__,
-                   Status
-                   );
   }
+  StandardLib->RecordAssertion (
+                  StandardLib,
+                  AssertionType,
+                  gSimpleNetworkBBTestFunctionAssertionGuid021,
+                  L"EFI_SIMPLE_NETWORK_PROTOCOL.NvData - Invoke NvData() to write and verify interface correctness within test case",
+                  L"%a:%d:Status - %r",
+                  __FILE__,
+                  (UINTN)__LINE__,
+                  Status
+                  );
 
 End:
   //
@@ -2322,9 +2304,14 @@ BBTestReceiveFunctionTest (
                            NULL
                            );
   if (EFI_ERROR(Status)) {
+    if (EFI_UNSUPPORTED == Status) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
     StandardLib->RecordAssertion (
                    StandardLib,
-                   EFI_TEST_ASSERTION_FAILED,
+                   AssertionType,
                    gTestGenericFailureGuid,
                    L"EFI_SIMPLE_NETWORK_PROTOCOL.Receive - Enable ReceiveFilters",
                    L"%a:%d:Status - %r",


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3145

The SimpleNetwork protocol related test cases don't allow some
functions to return EFI_UNSUPPORTED, which doesn't comply with UEFI
spec.

UEFI spec allows EFI_SIMPLE_TEXT_OUT_PROTOCOL functions below to
return EFI_UNSUPPORTED.
 - ReceiveFilters()
 - Statistics()
 - NvData()
 - StationAddress()
 - Reset()

Therefore, update the test cases that consume the functions above
to fix this issue.

Cc: G Edhaya Chandran <edhaya.chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Cc: Carolyn Gjertsen <Carolyn.Gjertsen@amd.com>
Cc: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>
Cc: Samer El-Haj-Mahmoud <samer.el-haj-mahmoud@arm.com>

Signed-off-by: Sunny Wang <sunny.wang@arm.com>