### PR TITLE
uefi-sct/SctPkg: Don't always check PixelInformation

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/GraphicsOutput/BlackBoxTest/GraphicsOutputBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/GraphicsOutput/BlackBoxTest/GraphicsOutputBBTestConformance.c
@@ -493,16 +493,28 @@ Returns:
                                  );
       if (Status != EFI_SUCCESS) {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
-      }   else {
+      } else {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
-      }
-
-      if (SctCompareMem (
-          (void *) info,
-          (void *) GraphicsOutput->Mode->Info,
-          sizeof (EFI_GRAPHICS_OUTPUT_MODE_INFORMATION)
-          ) != 0) {
-        AssertionType = EFI_TEST_ASSERTION_FAILED;
+        if (info != NULL) {
+          //
+          // PixelInformation is checked only if PixelFormat is PixelBitMask
+          //
+          if ( info->Version              != GraphicsOutput->Mode->Info->Version
+            || info->HorizontalResolution != GraphicsOutput->Mode->Info->HorizontalResolution
+            || info->VerticalResolution   != GraphicsOutput->Mode->Info->VerticalResolution
+            || info->PixelFormat          != GraphicsOutput->Mode->Info->PixelFormat
+            || info->PixelsPerScanLine    != GraphicsOutput->Mode->Info->PixelsPerScanLine
+            || ( info->PixelFormat == PixelBitMask
+              && ( info->PixelInformation.RedMask      != GraphicsOutput->Mode->Info->PixelInformation.RedMask
+                || info->PixelInformation.GreenMask    != GraphicsOutput->Mode->Info->PixelInformation.GreenMask
+                || info->PixelInformation.BlueMask     != GraphicsOutput->Mode->Info->PixelInformation.BlueMask
+                || info->PixelInformation.ReservedMask != GraphicsOutput->Mode->Info->PixelInformation.ReservedMask)))
+          {
+            AssertionType = EFI_TEST_ASSERTION_FAILED;
+          }
+        } else {
+          AssertionType = EFI_TEST_ASSERTION_FAILED;
+        }
       }
 
       if (info != NULL) {

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/GraphicsOutput/BlackBoxTest/GraphicsOutputBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/GraphicsOutput/BlackBoxTest/GraphicsOutputBBTestFunction.c
@@ -125,11 +125,20 @@ Returns:
     } else {
       AssertionType = EFI_TEST_ASSERTION_PASSED;
       if (Info != NULL) {
-        if (SctCompareMem (
-            (void *) Info,
-            (void *) GraphicsOutput->Mode->Info,
-            sizeof (EFI_GRAPHICS_OUTPUT_MODE_INFORMATION)
-            ) != 0) {
+        //
+        // PixelInformation is checked only if PixelFormat is PixelBitMask
+        //
+        if ( Info->Version              != GraphicsOutput->Mode->Info->Version
+          || Info->HorizontalResolution != GraphicsOutput->Mode->Info->HorizontalResolution
+          || Info->VerticalResolution   != GraphicsOutput->Mode->Info->VerticalResolution
+          || Info->PixelFormat          != GraphicsOutput->Mode->Info->PixelFormat
+          || Info->PixelsPerScanLine    != GraphicsOutput->Mode->Info->PixelsPerScanLine
+          || ( Info->PixelFormat == PixelBitMask
+            && ( Info->PixelInformation.RedMask      != GraphicsOutput->Mode->Info->PixelInformation.RedMask
+              || Info->PixelInformation.GreenMask    != GraphicsOutput->Mode->Info->PixelInformation.GreenMask
+              || Info->PixelInformation.BlueMask     != GraphicsOutput->Mode->Info->PixelInformation.BlueMask
+              || Info->PixelInformation.ReservedMask != GraphicsOutput->Mode->Info->PixelInformation.ReservedMask)))
+        {
           AssertionType = EFI_TEST_ASSERTION_FAILED;
         }
       } else {


### PR DESCRIPTION
According to UEFI 2.9 Section 12.9, the PixelInformation field of the
EFI_GRAPHICS_OUTPUT_MODE_INFORMATION structure is valid only if
PixelFormat is PixelBitMask. The current implementation always checks
the contents of PixelInformation field of the
EFI_GRAPHICS_OUTPUT_MODE_INFORMATION structure returned by QueryMode,
regardless of PixelFormat. Check PixelInformation only if
PixelFormat is PixelBitMask.

Cc: G Edhaya Chandran <Edhaya.Chandran@...>
Cc: Jeff Booher-Kaeding <Jeff.Booher-Kaeding@...>
Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@...>
Cc: Sunny Wang <Sunny.Wang@...>
Cc: Jeremy Linton <Jeremy.Linton@...>

Signed-off-by: Dimitrije Pavlov <Dimitrije.Pavlov@...>

Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>
Reviewed-by: Sunny Wang <sunny.wang@arm.com>