### PR TITLE
Changes to the delay interval in the Stall_Func test

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c
@@ -827,7 +827,7 @@ BBTestStallInterfaceTest (
       StartTime = Epoch;
     OldTpl = gtBS->RaiseTPL (TplArray[Index]);
     Status = gtBS->Stall (
-                     10000000
+                     4000000
                      );
     gtBS->RestoreTPL (OldTpl);
     if (gtRT->GetTime (&EndTime, NULL) != EFI_SUCCESS)

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestMain.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestMain.h
@@ -46,7 +46,7 @@ typedef struct _RESET_DATA {
  { 0xA6033499, 0xE4AF, 0x44f5, {0x9D, 0x16, 0x30, 0x78, 0xD8, 0x61, 0x32, 0x28 }}
 
 #define TPL_ARRAY_SIZE 3
-#define MAX_SECOND_MARGIN 2
+#define MAX_SECOND_MARGIN 1
 
 //
 // Change size from TPL_ARRAY_SIZE to TPL_ARRAY_SIZE + 1


### PR DESCRIPTION
Running the Stall_Func test on `TPL_HIGH_LEVEL` can sometimes cause the test to corrupt the disk, preventing further testing due to the disabling of interrupts. We found that this test will often fail and corrupt the disk due to triggering NVMe I/O timeouts by exceeding a delay of five seconds.

This PR changes the 10 second delay to 4 seconds to avoids this and tightens the response interval from a delta of two seconds to one to adapt to this change in delay.