### PR TITLE
Update capsule header guid

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTest.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTest.inf
@@ -52,3 +52,6 @@
 
 [Protocols]
   gEfiTestRecoveryLibraryGuid
+
+[Guids]
+  gWindowsUxCapsuleGuid

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTestConformance.c
@@ -81,7 +81,7 @@ BBTestUpdateCapsuleConformanceTest (
   }
 
   CapsuleHeaderArray[0] = (EFI_CAPSULE_HEADER *) (UINTN)AllocatedBuffer;
-  CapsuleHeaderArray[0]->CapsuleGuid = mEfiCapsuleHeaderGuid;
+  CapsuleHeaderArray[0]->CapsuleGuid = gWindowsUxCapsuleGuid;
   CapsuleHeaderArray[0]->HeaderSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[0]->CapsuleImageSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[1] = NULL;
@@ -116,7 +116,7 @@ BBTestUpdateCapsuleConformanceTest (
   //
 
   CapsuleHeaderArray[0] = (EFI_CAPSULE_HEADER *) (UINTN)AllocatedBuffer;
-  CapsuleHeaderArray[0]->CapsuleGuid = mEfiCapsuleHeaderGuid;
+  CapsuleHeaderArray[0]->CapsuleGuid = gWindowsUxCapsuleGuid;
   CapsuleHeaderArray[0]->HeaderSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[0]->CapsuleImageSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[1] = NULL;
@@ -150,7 +150,7 @@ BBTestUpdateCapsuleConformanceTest (
   // CAPSULE_FLAGS_PERSIST_ACROSS_RESET set in its header as well.
   //
   CapsuleHeaderArray[0] = (EFI_CAPSULE_HEADER *) (UINTN)AllocatedBuffer;
-  CapsuleHeaderArray[0]->CapsuleGuid = mEfiCapsuleHeaderGuid;
+  CapsuleHeaderArray[0]->CapsuleGuid = gWindowsUxCapsuleGuid;
   CapsuleHeaderArray[0]->HeaderSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[0]->CapsuleImageSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[1] = NULL;
@@ -182,7 +182,7 @@ BBTestUpdateCapsuleConformanceTest (
   // CAPSULE_FLAGS_PERSIST_ACROSS_RESET set in its header as well.
   //
   CapsuleHeaderArray[0] = (EFI_CAPSULE_HEADER *) (UINTN)AllocatedBuffer;
-  CapsuleHeaderArray[0]->CapsuleGuid = mEfiCapsuleHeaderGuid;
+  CapsuleHeaderArray[0]->CapsuleGuid = gWindowsUxCapsuleGuid;
   CapsuleHeaderArray[0]->HeaderSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[0]->CapsuleImageSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[1] = NULL;
@@ -268,7 +268,7 @@ BBTestQueryCapsuleCapabilitiesConformanceTest (
   }
 
   CapsuleHeaderArray[0] = (EFI_CAPSULE_HEADER *) (UINTN)AllocatedBuffer;
-  CapsuleHeaderArray[0]->CapsuleGuid = mEfiCapsuleHeaderGuid;
+  CapsuleHeaderArray[0]->CapsuleGuid = gWindowsUxCapsuleGuid;
   CapsuleHeaderArray[0]->HeaderSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[0]->CapsuleImageSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[1] = NULL;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTestFunction.c
@@ -463,7 +463,7 @@ BBTestQueryCapsuleCapabilitiesTest (
 
   CapsuleHeaderArray[0] = (EFI_CAPSULE_HEADER *) AllocatedBuffer;
   CapsuleHeaderArray[1] = NULL;
-  CapsuleHeaderArray[0]->CapsuleGuid = mEfiCapsuleHeaderGuid;
+  CapsuleHeaderArray[0]->CapsuleGuid = gWindowsUxCapsuleGuid;
   CapsuleHeaderArray[0]->CapsuleImageSize = sizeof(EFI_CAPSULE_HEADER);
   CapsuleHeaderArray[0]->HeaderSize = sizeof(EFI_CAPSULE_HEADER);
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTestMain.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTestMain.c
@@ -27,10 +27,6 @@ Abstract:
 #include "SctLib.h"
 #include "MiscRuntimeServicesBBTestMain.h"
 
-#if (EFI_SPECIFICATION_VERSION >= 0x00020000)
-EFI_GUID mEfiCapsuleHeaderGuid = EFI_CAPSULE_GUID;
-#endif
-
 EFI_TPL TplArray [TPL_ARRAY_SIZE] = {
   TPL_APPLICATION,
   TPL_CALLBACK,

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTestMain.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/MiscRuntimeServices/BlackBoxTest/MiscRuntimeServicesBBTestMain.h
@@ -50,14 +50,7 @@ typedef struct _RESET_DATA {
 
 #define TPL_ARRAY_SIZE 3
 
-#ifndef EFI_CAPSULE_GUID
-#define EFI_CAPSULE_GUID \
-  { 0x3B6686BD, 0x0D76, 0x4030, {0xB7, 0x0E, 0xB5, 0x51, 0x9E, 0x2F, 0xC5, 0xA0 }}
-#endif
-
 extern EFI_TPL TplArray[TPL_ARRAY_SIZE];
-
-extern EFI_GUID  mEfiCapsuleHeaderGuid;
 
 //
 // Prototypes of Interface Test


### PR DESCRIPTION
UpdateCapsule() Conformance requires that a capsule marked CAPSULE_FLAGS_PERSIST_ACROSS_RESET must also provide a valid ScatterGatherList. In some platforms (See example [HERE](https://github.com/microsoft/mu_basecore/blob/2f7175d6bb584d5de26d6d7deb0b6da5ff6dd5c0/MdeModulePkg/Universal/CapsuleRuntimeDxe/CapsuleService.c#L182)), however, if a capsule is marked as such, the capsule is validated before being persisted in memory (which is when the ScatterGatherList is verified). Due to this, those platforms fail the SCT that validates this conformance as they return EFI_UNSUPPORTED as the capsule header guid being passed to the function is not a known valid capsule header guid.

This commit updates the capsule header guid used in the MiscRuntimeService tests to use a known good capsule header guid, gWindowsUxCapsuleGuid, which causes these platforms to pass this SCT by reaching the ScatterGatherList validation, which then returns EFI_INVALID_PARAMETER.