### PR TITLE
MiscBootServices: Stall_Func: Reduces the stall interval for Stall_Func

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestFunction.c
@@ -827,7 +827,7 @@ BBTestStallInterfaceTest (
       StartTime = Epoch;
     OldTpl = gtBS->RaiseTPL (TplArray[Index]);
     Status = gtBS->Stall (
-                     10000000
+                     4000000^M
                      );
     gtBS->RestoreTPL (OldTpl);
     if (gtRT->GetTime (&EndTime, NULL) != EFI_SUCCESS)
@@ -845,7 +845,7 @@ BBTestStallInterfaceTest (
                    (Index == 1? \
                     gMiscBootServicesBBTestFunctionAssertionGuid021: \
                     gMiscBootServicesBBTestFunctionAssertionGuid022),
-                   L"BS.Stall - 10 seconds",
+                   L"BS.Stall - 4 seconds",^M
                    L"%a:%d:Status - %r, TPL - %d",
                    __FILE__,
                    (UINTN)__LINE__,
@@ -853,8 +853,8 @@ BBTestStallInterfaceTest (
                    TplArray[Index]
                    );
     SecondsElapsed = GetSecondsElapsed (&StartTime, &EndTime);
-    if ((SecondsElapsed <= 10 + MAX_SECOND_MARGIN) &&
-         (SecondsElapsed >= 10 - MAX_SECOND_MARGIN)) {
+    if ((SecondsElapsed <= 4 + MAX_SECOND_MARGIN) &&^M
+         (SecondsElapsed >= 4 - MAX_SECOND_MARGIN)) {^M
       AssertionType = EFI_TEST_ASSERTION_PASSED;
     } else {
       AssertionType = EFI_TEST_ASSERTION_FAILED;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestMain.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/MiscBootServices/BlackBoxTest/MiscBootServicesBBTestMain.h
@@ -46,7 +46,7 @@ typedef struct _RESET_DATA {
  { 0xA6033499, 0xE4AF, 0x44f5, {0x9D, 0x16, 0x30, 0x78, 0xD8, 0x61, 0x32, 0x28 }}
 
 #define TPL_ARRAY_SIZE 3
-#define MAX_SECOND_MARGIN 2
+#define MAX_SECOND_MARGIN 1^M
 
 //
 // Change size from TPL_ARRAY_SIZE to TPL_ARRAY_SIZE + 1


### PR DESCRIPTION
The Stall_Func test on the highest TPL causes issues with the disk IO by blocking interrupts. This blocking can cause disk corruption through IO timeouts. Since this doesn't seem to be the intent of the test this revision reduces the stall interval from 10 seconds to 4 and adjusts the delta tolerance in scale.

Signed-off-by: Robert Wood <rwood.ce@comcast.net>

Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>

Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>
Reviewed-by: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>