### PR TITLE
Enable LoongArch64

### DIFF
--- a/uefi-sct/SctPkg/Application/InstallSct/InstallSctDef.h
+++ b/uefi-sct/SctPkg/Application/InstallSct/InstallSctDef.h
@@ -4,6 +4,7 @@
   Copyright (c) 2010 - 2017, Intel Corporation. All rights reserved.<BR>
   Portions copyright (c) 2014, ARM Ltd. All rights reserved.<BR>
   (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -36,6 +37,9 @@
 #elif defined(EFIRISCV64)
   #define INSTALL_SCT_PLATFORM_SHORT_NAME   L"riscv64"
   #define INSTALL_SCT_PLATFORM_NAME         L"RISCV64"
+#elif defined(EFILOONGARCH64)
+  #define INSTALL_SCT_PLATFORM_SHORT_NAME   L"loongarch64"
+  #define INSTALL_SCT_PLATFORM_NAME         L"LOONGARCH64"
 #else
   #error "Architecture not supported"
 #endif

--- a/uefi-sct/SctPkg/Library/SctLib/LoongArch64/SctLibPlat.h
+++ b/uefi-sct/SctPkg/Library/SctLib/LoongArch64/SctLibPlat.h
@@ -1,0 +1,32 @@
+/** @file
+
+  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
+  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  SctLibPlat.h
+
+Abstract:
+
+  LoongArch64 specific defines
+
+--*/
+
+#ifndef _EFI_LIB_PLAT_H_
+#define _EFI_LIB_PLAT_H_
+
+#define MIN_ALIGNMENT_SIZE  8
+
+#endif

--- a/uefi-sct/SctPkg/Library/SctLib/LoongArch64/initplat.c
+++ b/uefi-sct/SctPkg/Library/SctLib/LoongArch64/initplat.c
@@ -1,0 +1,45 @@
+/** @file
+
+  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
+  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  initplat.c
+
+Abstract:
+
+  Math routines for compatibility with native EFI library routines.
+
+--*/
+
+#include "SctLibInternal.h"
+
+VOID
+InitializeLibPlatform (
+    IN EFI_HANDLE           ImageHandle,
+    IN EFI_SYSTEM_TABLE     *SystemTable
+    )
+
+{
+  // No platform-specific initializations
+}
+
+UINT64
+SctReadTsc (
+  VOID
+  )
+{
+  return 0;
+}

--- a/uefi-sct/SctPkg/Library/SctLib/SctLib.inf
+++ b/uefi-sct/SctPkg/Library/SctLib/SctLib.inf
@@ -4,6 +4,7 @@
 #  Copyright (c) 2013 - 2014, ARM Ltd. All rights reserved.<BR>
 #  Copyright (c) 2014 - 2019, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -66,6 +67,11 @@
 [sources.RISCV64]
   Riscv64/SctLibPlat.h
   Riscv64/initplat.c
+  Math.c
+
+[sources.LOONGARCH64]
+  LoongArch64/SctLibPlat.h
+  LoongArch64/initplat.c
   Math.c
 
 [sources.ia32]

--- a/uefi-sct/SctPkg/SCRT/SCRTApp/LoongArch64/GoVirtual.S
+++ b/uefi-sct/SctPkg/SCRT/SCRTApp/LoongArch64/GoVirtual.S
@@ -1,0 +1,41 @@
+## @file
+#
+#  Copyright 2010 - 2012 Unified EFI, Inc.<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+#
+#  This program and the accompanying materials
+#  are licensed and made available under the terms and conditions of the BSD License
+#  which accompanies this distribution.  The full text of the license may be found at
+#  http://opensource.org/licenses/bsd-license.php
+#
+#  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+#
+##
+#
+#
+#/*++
+#
+# Module Name:
+#
+#  GoVirtual.S
+#
+#--*/
+#start of the code section
+
+ASM_GLOBAL ASM_PFX(JumpToTestFunc)
+
+#------------------------------------------------------------------------------
+# VOID
+# JumpToTestFunc (
+#   IN  UINTN  FuncPointer,
+#   IN  UNITN  ConfigInfo
+#   )
+#
+ASM_PFX(JumpToTestFunc):
+  move  $ra, $a0
+  move  $a0, $a1
+
+  // Jump to Virtual function
+  jirl  $zero, $ra, 0
+  .end

--- a/uefi-sct/SctPkg/SCRT/SCRTApp/LoongArch64/VirtualMemory.c
+++ b/uefi-sct/SctPkg/SCRT/SCRTApp/LoongArch64/VirtualMemory.c
@@ -1,0 +1,177 @@
+/** @file
+
+  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
+  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  VirtualMemory.c
+
+--*/
+
+#include "SCRTApp.h"
+
+UINTN       PageTable   = 0;
+
+
+VOID
+ConvertRuntimeFuncPtr (
+  IN OUT UINTN      *VirtualFunc
+  )
+/*++
+
+Routine Description:
+
+  Change RuntimeTestFunc physical address to virtual address
+
+Arguments:
+
+  VirtualFunc  - On input, RuntimeTestFunc physical address.
+                 On output, RuntimeTest virtual address.
+
+Returns:
+
+  NONE
+
+--*/
+{
+  /*Note: It is presumed that on LoongArch architecture the MMU is
+   * configured and enabled in PEI phase. As VirtualFunc is already
+   * mapped to virtual memory, don't have to do anything here.
+   */
+}
+
+
+EFI_STATUS
+DoMemoryAllocation (
+  IN UINTN PhysicalFunc
+  )
+/*++
+
+Routine Description:
+
+  Allocate memory and create the PageTable to set up physical-virtual map.
+
+Arguments:
+
+  PhysicalFunc  - Physical address where RuntimeTestFunc locates.
+
+Returns:
+
+  EFI_STATUS
+
+--*/
+{
+  EFI_STATUS                  Status;
+  EFI_PHYSICAL_ADDRESS        AllocateMemory;
+
+  //create new page tables or use existing page tables.
+  //
+  // Allocate PageTable memory close to this Application image location in
+  // the system memory. In this way, it is safe for page table memory.
+  //
+  AllocateMemory = PhysicalFunc;
+
+  Status = tBS->AllocatePages (
+                  AllocateMaxAddress,
+                  EfiRuntimeServicesData,
+                  1,
+                  &AllocateMemory
+                  );
+
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
+
+  PageTable = (UINTN)AllocateMemory;
+  return EFI_SUCCESS;
+}
+
+
+VOID
+PrepareVirtualAddressMap (
+  IN UINTN                       MemoryMapSize,
+  IN UINTN                       DescriptorSize,
+  IN EFI_MEMORY_DESCRIPTOR       *MemoryMap,
+  IN EFI_MEMORY_DESCRIPTOR       *VirtualMemoryMap,
+  IN OUT UINTN                   *VirtualMapSize
+  )
+/*++
+
+Routine Description:
+
+  Construct VirtualAddressMap from physical address to virtual address
+
+Arguments:
+
+  MemoryMapSize     - The size, in bytes, of the MemoryMap buffer
+  DescriptorSize    - The size, in bytes, of an individual EFI_MEMORY_DESCRIPTOR
+  MemoryMap         - A pointer to the current memory map
+  VirtualMemoryMap  - A pointer to the modified virtual memory map
+  VirtualMapSize    - A pointer to the size, in bytes, of the VirtualMemoryMap buffer
+
+Returns:
+
+  NONE
+
+--*/
+{
+  UINTN    Index;
+  *VirtualMapSize        = 0;
+
+  //
+  // Copy entries that need runtime mapping to construct virtualMemoryMap
+  //
+  for (Index = 0; Index < (MemoryMapSize / DescriptorSize); Index++) {
+    if ((MemoryMap->Attribute & EFI_MEMORY_RUNTIME) == EFI_MEMORY_RUNTIME) {
+      SctCopyMem ((VOID *) VirtualMemoryMap, (VOID *) MemoryMap, DescriptorSize);
+      VirtualMemoryMap->VirtualStart  = VirtualMemoryMap->PhysicalStart;
+      *VirtualMapSize += DescriptorSize;
+      VirtualMemoryMap = NextMemoryDescriptor (VirtualMemoryMap, DescriptorSize);
+    }
+
+    MemoryMap = NextMemoryDescriptor (MemoryMap, DescriptorSize);
+  }
+}
+
+
+
+VOID
+JumpVirtualMode(
+  IN UINTN VirtualFunc,
+  IN UINTN HandOffAddr
+  )
+/*++
+
+Routine Description:
+
+  Enable virtual addressing mode, and jump to RuntimeTestFunc in virtual address
+
+Arguments:
+
+  VirtualFunc  - RuntimeTestFunc virtual address
+  HandOffAddr  - Configuration Data Address
+
+Returns:
+
+  NONE
+
+--*/
+{
+  //
+  // Note: It is assumed that the MMU and page tables are configured on LoongArch
+  // platforms.
+  //
+  JumpToTestFunc(VirtualFunc, HandOffAddr);
+}

--- a/uefi-sct/SctPkg/SCRT/SCRTApp/SCRTApp.inf
+++ b/uefi-sct/SctPkg/SCRT/SCRTApp/SCRTApp.inf
@@ -3,6 +3,7 @@
 #  Copyright 2006 - 2016 Unified EFI, Inc.<BR>
 #  Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -43,6 +44,10 @@
 [sources.RISCV64]
   Riscv64/VirtualMemory.c
   Riscv64/GoVirtual.S | GCC
+
+[sources.LOONGARCH64]
+  LoongArch64/VirtualMemory.c
+  LoongArch64/GoVirtual.S | GCC
 
 [sources.ia32]
   ia32/VirtualMemory.c

--- a/uefi-sct/SctPkg/SCRT/SCRTDriver/LoongArch64/Debug.c
+++ b/uefi-sct/SctPkg/SCRT/SCRTDriver/LoongArch64/Debug.c
@@ -1,0 +1,81 @@
+/** @file
+
+  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
+  Copyright (c) 2011 - 2012 ARM Ltd. All rights reserved.<BR>
+  Copyright (c) 2021 Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+/*++
+
+Module Name:
+
+  Debug.c
+
+--*/
+
+#include "SCRTDriver.h"
+
+UINTN                 mHandOffPtr        =  0;
+
+
+EFI_STATUS
+ConsumeHandOff (
+  IN  UINTN         HandOffAddr,
+  OUT CONF_INFO     *ConfigData
+  )
+{
+   RUNTIME_HANDOFF   *HandOffPtr;
+   //
+   // First fix the memory address of hand off data.
+   //
+   FixAddress(&HandOffAddr);
+   mHandOffPtr = HandOffAddr;
+   HandOffPtr  = (RUNTIME_HANDOFF*)mHandOffPtr;
+   *ConfigData =  HandOffPtr->ConfigureInfo;
+
+   //
+   // Fix MmioBase Address.
+   //
+   FixAddress(&HandOffPtr->DebuggerInfo.MmioBase);
+
+   return EFI_SUCCESS;
+}
+
+
+EFI_STATUS
+Send2UART (
+  CHAR8                *String
+  )
+{
+  //
+  // TODO: On LoongArch platforms use platform specific functions to
+  // write the data to UART.
+  //
+  return EFI_SUCCESS;
+}
+
+
+
+EFI_STATUS
+DebugWorker (
+  IN CHAR8    *String
+  )
+{
+  EFI_STATUS    Status;
+
+  //
+  // Send text message to registered UART.
+  //
+  Status = Send2UART(String);
+  return Status;
+}

--- a/uefi-sct/SctPkg/SCRT/SCRTDriver/LoongArch64/Dump.c
+++ b/uefi-sct/SctPkg/SCRT/SCRTDriver/LoongArch64/Dump.c
@@ -1,0 +1,68 @@
+/** @file
+
+  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
+  Copyright (c) 2011 - 2012 ARM Ltd. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+/*++
+
+Module Name:
+
+  Dump.c
+
+--*/
+
+#include "SCRTDriver.h"
+
+VOID
+DumpRuntimeTable()
+{
+  Printf ("\n================Dump Runtime Table===============\n");
+  Printf ("Header Signature = 0x%x\n", VRT->Hdr.Signature);
+
+  Printf ("\n================GetTime Service==============\n");
+  Printf ("GetTime @ 0x%x\n", VRT->GetTime);
+
+  Printf ("\n================SetTime Service==============\n");
+  Printf ("SetTime @ 0x%x\n", VRT->SetTime);
+
+  Printf ("\n================GetWakeupTime Service==============\n");
+  Printf ("GetWakeupTime @ 0x%x\n", VRT->GetWakeupTime);
+
+  Printf ("\n================SetWakeupTime Service==============\n");
+  Printf ("SetWakeupTime @ 0x%x\n", VRT->SetWakeupTime);
+
+  Printf ("\n================GetVariable Service==============\n");
+  Printf ("GetVariable @ 0x%x\n", VRT->GetVariable);
+
+  Printf ("\n================GetNextVariableName Service==============\n");
+  Printf ("GetNextVariableName @ 0x%x\n", VRT->GetNextVariableName);
+
+  Printf ("\n================SetVariable Service==============\n");
+  Printf ("SetVariable @ 0x%x\n", VRT->SetVariable);
+
+  Printf ("\n================GetNextHighMonotonicCount Service==============\n");
+  Printf ("GetNextHighMonotonicCount @ 0x%x\n", VRT->GetNextHighMonotonicCount);
+
+  Printf ("\n================ResetSystem Service==============\n");
+  Printf ("ResetSystem @ 0x%x\n", VRT->ResetSystem);
+#if 0
+  Printf ("\n================UpdateCapsule Service==============\n");
+  Printf ("UpdateCapsule @ 0x%x\n", VRT->UpdateCapsule);
+
+  Printf ("\n================QueryCapsuleCapabilities Service==============\n");
+  Printf ("QueryCapsuleCapabilities @ 0x%x\n", VRT->QueryCapsuleCapabilities);
+
+  Printf ("\n================QueryVariableInfo Service==============\n");
+  Printf ("QueryVariableInfo @ 0x%x\n", VRT->QueryVariableInfo);
+#endif
+}

--- a/uefi-sct/SctPkg/SCRT/SCRTDriver/LoongArch64/Io.c
+++ b/uefi-sct/SctPkg/SCRT/SCRTDriver/LoongArch64/Io.c
@@ -1,0 +1,136 @@
+/** @file
+
+  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
+  Copyright (c) 2011 - 2012 ARM Ltd. All rights reserved.<BR>
+  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+
+/*++
+
+Module Name:
+
+  Io.c
+
+--*/
+
+#include "SCRTDriver.h"
+
+EFI_STATUS
+EFIAPI
+CpuIoServiceWrite (
+  IN EFI_PEI_CPU_IO_PPI_WIDTH  Width,
+  IN UINT64                     UserAddress,
+  IN UINTN                      Count,
+  IN VOID                       *UserBuffer
+  )
+/*++
+
+Routine Description:
+
+  Perform the port I/O write service
+
+Arguments:
+
+  Width   - Width of the port I/O operation
+  Address - Base address of the port I/O operation
+  Count   - Count of the number of accesses to perform
+  Buffer  - Pointer to the source buffer from which to write data
+
+Returns:
+
+  EFI_SUCCESS           - The data was written.
+  EFI_INVALID_PARAMETER - Width is invalid.
+  EFI_INVALID_PARAMETER - Buffer is NULL.
+  EFI_UNSUPPORTED       - The Buffer is not aligned for the given Width.
+  EFI_UNSUPPORTED       - The address range specified by Address, Width,
+                          and Count is not valid.
+
+--*/
+{
+  return EFI_UNSUPPORTED;
+}
+
+
+EFI_STATUS
+EfiIoWrite (
+  IN     EFI_PEI_CPU_IO_PPI_WIDTH  Width,
+  IN     UINT64                     Address,
+  IN     UINTN                      Count,
+  IN OUT VOID                       *Buffer
+  )
+/*++
+
+Routine Description:
+  Perform an IO write into Buffer.
+
+Arguments:
+  Width   - Width of write transaction, and repeat operation to use
+  Address - IO address to write
+  Count   - Number of times to write the IO address.
+  Buffer  - Buffer to write data from. size is Width * Count
+
+Returns:
+  Status code
+
+--*/
+{
+  return CpuIoServiceWrite(Width, Address, Count, Buffer);
+}
+
+
+EFI_STATUS
+EfiIoRead (
+  IN     EFI_PEI_CPU_IO_PPI_WIDTH  Width,
+  IN     UINT64                     Address,
+  IN     UINTN                      Count,
+  IN OUT VOID                       *Buffer
+  )
+/*++
+
+Routine Description:
+  Perform an IO read into Buffer.
+
+Arguments:
+  Width   - Width of read transaction, and repeat operation to use
+  Address - IO address to read
+  Count   - Number of times to read the IO address.
+  Buffer  - Buffer to read data into. size is Width * Count
+
+Returns:
+  Status code
+
+--*/
+{
+  return EFI_UNSUPPORTED;
+}
+
+
+VOID
+FixAddress (
+  IN UINTN     *PhyAddress
+  )
+{
+  //
+  //Note: On LoongArch platforms don't have to do this as all the functions are virtually mapped.
+  //
+}
+
+// Quick port to LoongArch. It doesn't have traditional I/O-Port 80h POST Codes
+
+VOID
+Port80 (
+  UINT8 Number
+  )
+{
+  //EFI_SCT_DEBUG ((EFI_SCT_D_ERROR, L"Port80 %02x", Number));
+}

--- a/uefi-sct/SctPkg/SCRT/SCRTDriver/SCRTDriver.inf
+++ b/uefi-sct/SctPkg/SCRT/SCRTDriver/SCRTDriver.inf
@@ -3,6 +3,7 @@
 #  Copyright 2006 - 2016 Unified EFI, Inc.<BR>
 #  Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -74,6 +75,11 @@
   Riscv64/Io.c
   Riscv64/Dump.c
   Riscv64/Debug.c
+
+[sources.LOONGARCH64]
+  LoongArch64/Io.c
+  LoongArch64/Dump.c
+  LoongArch64/Debug.c
 
 [sources.common]
   Guid.h

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DebugSupport/BlackBoxTest/DebugSupportBBTest.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DebugSupport/BlackBoxTest/DebugSupportBBTest.inf
@@ -4,6 +4,7 @@
 #  Copyright (c) 2010 - 2012, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) 2019, ARM Ltd. All rights reserved.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -72,6 +73,11 @@
   Riscv64/PlatformIsa.c
   Riscv64/DebugSupportBBTestExceptionCallbackFunction.c
   Riscv64/DebugSupportBBTestCacheFunction.c
+
+[sources.LOONGARCH64]
+  LoongArch64/PlatformIsa.c
+  LoongArch64/DebugSupportBBTestExceptionCallbackFunction.c
+  LoongArch64/DebugSupportBBTestCacheFunction.c
 
 [Packages]
   SctPkg/SctPkg.dec

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DebugSupport/BlackBoxTest/LoongArch64/DebugSupportBBTestCacheFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DebugSupport/BlackBoxTest/LoongArch64/DebugSupportBBTestCacheFunction.c
@@ -1,0 +1,136 @@
+/** @file
+
+  Copyright 2006 - 2016 Unified EFI, Inc.<BR>
+  Copyright (c) 2011 - 2016, ARM Ltd. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  DebugSupportBBTestCacheFunction.c
+
+Abstract:
+
+  Interface Function Test Cases of Debug Support Protocol
+
+--*/
+
+
+#include "DebugSupportBBTestMain.h"
+
+/**
+ *  Entrypoint for EFI_DEBUG_SUPPORT_PROTOCOL.InvalidateInstructionCache() Function Test.
+ *  @param This a pointer of EFI_BB_TEST_PROTOCOL.
+ *  @param ClientInterface a pointer to the interface to be tested.
+ *  @param TestLevel test "thoroughness" control.
+ *  @param SupportHandle a handle containing protocols required.
+ *  @return EFI_SUCCESS Finish the test successfully.
+ */
+//
+// TDS 3.5
+//
+EFI_STATUS
+BBTestInvalidateInstructionCacheFunctionAutoTest (
+  IN EFI_BB_TEST_PROTOCOL       *This,
+  IN VOID                       *ClientInterface,
+  IN EFI_TEST_LEVEL             TestLevel,
+  IN EFI_HANDLE                 SupportHandle
+  )
+{
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL   *StandardLib;
+  EFI_STATUS                           Status;
+  EFI_DEBUG_SUPPORT_PROTOCOL           *DebugSupport;
+  EFI_TEST_ASSERTION                   AssertionType;
+  UINT64                               Start;
+  UINT64                               Length;
+  UINTN                                MaxProcessorIndex;
+  UINTN                                ProcessorIndex;
+
+  //
+  // Get the Standard Library Interface
+  //
+  Status = gtBS->HandleProtocol (
+                   SupportHandle,
+                   &gEfiStandardTestLibraryGuid,
+                   (VOID **) &StandardLib
+                   );
+
+  if (EFI_ERROR(Status)) {
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   EFI_TEST_ASSERTION_FAILED,
+                   gTestGenericFailureGuid,
+                   L"BS.HandleProtocol - Handle standard test library",
+                   L"%a:%d:Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   Status
+                   );
+    return Status;
+  }
+
+  DebugSupport = (EFI_DEBUG_SUPPORT_PROTOCOL *)ClientInterface;
+
+  if (DebugSupport->Isa != PlatformIsa) {
+    return EFI_SUCCESS;
+  }
+
+  Status = DebugSupport->GetMaximumProcessorIndex (DebugSupport, &MaxProcessorIndex);
+  if (EFI_ERROR(Status)) {
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   EFI_TEST_ASSERTION_FAILED,
+                   gTestGenericFailureGuid,
+                   L"EFI_DEBUG_SUPPORT_PROTOCOL.GetMaximumProcessorIndex",
+                   L"%a:%d:Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   Status
+                   );
+    return Status;
+  }
+
+  for (ProcessorIndex = 0; ProcessorIndex <= MaxProcessorIndex; ProcessorIndex++) {
+
+    //
+    // Assertion Point 3.5.2.1
+    // Invoke InvalidateInstructionCache and verify interface correctness.
+    //
+
+    // The Physical base of the memory range to be invalidated.
+    Start  = 0x0;
+
+    // The minimum number of bytes in the processor's instruction cache to be invalidated.
+    Length = 0x0;
+
+    Status = DebugSupport->InvalidateInstructionCache (DebugSupport, ProcessorIndex, (VOID*)&Start, Length);
+
+    if (EFI_ERROR(Status)) {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    }
+
+    StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gDebugSupportBBTestFunctionAssertionGuid015,
+                 L"EFI_DEBUG_SUPPORT_PROTOCOL.InvalidateInstructionCache - Invoke this function and verify interface correctness",
+                 L"%a:%d:Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+  }
+
+  return EFI_SUCCESS;
+}

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DebugSupport/BlackBoxTest/LoongArch64/DebugSupportBBTestExceptionCallbackFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DebugSupport/BlackBoxTest/LoongArch64/DebugSupportBBTestExceptionCallbackFunction.c
@@ -1,0 +1,273 @@
+/** @file
+
+  Copyright 2006 - 2016 Unified EFI, Inc.<BR>
+  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  DebugSupportBBExceptionCallbackFunction.c
+
+Abstract:
+
+  Interface Function Test Cases of Debug Support Protocol
+
+--*/
+
+
+#include "DebugSupportBBTestMain.h"
+
+extern volatile  UINTN InvokedExceptionCallback;
+extern volatile  UINTN InvokedPeriodicCallback;
+
+extern EFI_INSTRUCTION_SET_ARCHITECTURE PlatformIsa;
+
+void
+SoftwareBreak (
+  void
+  )
+{
+  // Not ported to LoongArch yet
+  ASSERT (FALSE);
+}
+
+/**
+ *  Entrypoint for EFI_DEBUG_SUPPORT_PROTOCOL.RegisterExceptionCallback() Function Test.
+ *  @param This a pointer of EFI_BB_TEST_PROTOCOL.
+ *  @param ClientInterface a pointer to the interface to be tested.
+ *  @param TestLevel test "thoroughness" control.
+ *  @param SupportHandle a handle containing protocols required.
+ *  @return EFI_SUCCESS Finish the test successfully.
+ */
+//
+// TDS 3.4
+//
+EFI_STATUS
+BBTestRegisterExceptionCallbackFunctionManualTest (
+  IN EFI_BB_TEST_PROTOCOL       *This,
+  IN VOID                       *ClientInterface,
+  IN EFI_TEST_LEVEL             TestLevel,
+  IN EFI_HANDLE                 SupportHandle
+  )
+{
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL   *StandardLib;
+  EFI_STATUS                           Status;
+  EFI_DEBUG_SUPPORT_PROTOCOL           *DebugSupport;
+  EFI_TEST_ASSERTION                   AssertionType;
+
+  DebugSupport = (EFI_DEBUG_SUPPORT_PROTOCOL *)ClientInterface;
+
+  if (DebugSupport->Isa != PlatformIsa) {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Get the Standard Library Interface
+  //
+  Status = gtBS->HandleProtocol (
+                   SupportHandle,
+                   &gEfiStandardTestLibraryGuid,
+                   (VOID **) &StandardLib
+                   );
+
+  if (EFI_ERROR(Status)) {
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   EFI_TEST_ASSERTION_FAILED,
+                   gTestGenericFailureGuid,
+                   L"BS.HandleProtocol - Handle standard test library",
+                   L"%a:%d:Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   Status
+                   );
+    return Status;
+  }
+
+  //
+  // Assertion Point 3.4.2.1
+  // Invoke RegisterExceptionCallback() to install an interrupt handler function.
+  //
+  InvokedExceptionCallback = FALSE;
+  Status = DebugSupport->RegisterExceptionCallback (DebugSupport, 0, ExceptionCallback, EXCEPT_LOONGARCH_BRK);
+
+  if ((Status == EFI_SUCCESS) || (Status == EFI_ALREADY_STARTED)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gDebugSupportBBTestFunctionAssertionGuid009,
+                 L"EFI_DEBUG_SUPPORT_PROTOCOL.RegisterExceptionCallback - Invoke this function and verify interface correctness",
+                 L"%a:%d:Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // If the callback function is already registed, return
+  //
+  if (EFI_ERROR(Status)) {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Test the callback function registed.
+  //
+
+  //
+  // Call SoftwareBreak to invoke the interrupt handler function.
+  //
+  SoftwareBreak ();
+
+  if (InvokedExceptionCallback == FALSE) {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gDebugSupportBBTestFunctionAssertionGuid010,
+                 L"EFI_DEBUG_SUPPORT_PROTOCOL.RegisterExceptionCallback - Verify the callback function was invoked.",
+                 L"%a:%d:Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // Assertion Point 3.4.2.2
+  // Invoke RegisterPeriodicCallback() to install the Periodic interrupt handler function.
+  // Verify the two callback functions can be both invoked.
+  //
+  InvokedExceptionCallback = FALSE;
+  InvokedPeriodicCallback  = FALSE;
+
+  Status = DebugSupport->RegisterPeriodicCallback (DebugSupport, 0, PeriodicCallback);
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
+
+  //
+  // Wait the PeriodicCallback to be invoked.
+  //
+  gtBS->Stall (500000);
+
+  //
+  // Call SoftwareBreak to invoke the interrupt handler function.
+  //
+  SoftwareBreak ();
+
+  if ((InvokedExceptionCallback == TRUE) && (InvokedPeriodicCallback == TRUE)) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gDebugSupportBBTestFunctionAssertionGuid011,
+                 L"EFI_DEBUG_SUPPORT_PROTOCOL.RegisterExceptionCallback - Verify the two callback functions can be both invoked.",
+                 L"%a:%d:Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // Uninstall the Periodic callback function.
+  //
+  Status = DebugSupport->RegisterPeriodicCallback (DebugSupport, 0, NULL);
+  if (EFI_ERROR(Status)) {
+    return Status;
+  }
+
+  //
+  // Assertion Point 3.4.2.3
+  // Invoke RegisterExceptionCallback() to install another interrupt handler function.
+  //
+  Status = DebugSupport->RegisterExceptionCallback (DebugSupport, 0, ExceptionCallback1, EXCEPT_LOONGARCH_BRK);
+
+  if (Status != EFI_ALREADY_STARTED) {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gDebugSupportBBTestFunctionAssertionGuid012,
+                 L"EFI_DEBUG_SUPPORT_PROTOCOL.RegisterExceptionCallback - Register another callback function.",
+                 L"%a:%d:Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // Assertion Point 3.4.2.4
+  // Invoke RegisterExceptionCallback() to unstall the interrupt handler function.
+  //
+  Status = DebugSupport->RegisterExceptionCallback (DebugSupport, 0, NULL, EXCEPT_LOONGARCH_BRK);
+
+  if (EFI_ERROR(Status)) {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gDebugSupportBBTestFunctionAssertionGuid013,
+                 L"EFI_DEBUG_SUPPORT_PROTOCOL.RegisterExceptionCallback - Invoke this function to uninstall the interrupt handler function",
+                 L"%a:%d:Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  InvokedExceptionCallback = FALSE;
+
+  //
+  // Call SoftwareBreak to invoke the interrupt handler function.
+  //
+  SoftwareBreak ();
+
+  if (InvokedExceptionCallback != FALSE) {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gDebugSupportBBTestFunctionAssertionGuid014,
+                 L"EFI_DEBUG_SUPPORT_PROTOCOL.RegisterExceptionCallback - Verify the callback function wasn't invoked",
+                 L"%a:%d:Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  return EFI_SUCCESS;
+}

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DebugSupport/BlackBoxTest/LoongArch64/PlatformIsa.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DebugSupport/BlackBoxTest/LoongArch64/PlatformIsa.c
@@ -1,0 +1,29 @@
+/** @file
+
+  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
+  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  PlatformIsa.c
+
+Abstract:
+
+  Platform related Isa definition.
+
+--*/
+
+#include "DebugSupportBBTestMain.h"
+
+EFI_INSTRUCTION_SET_ARCHITECTURE PlatformIsa = IsaLoongArch64;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/Usb2Hc/BlackBoxTest/Usb2HcTest.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/Usb2Hc/BlackBoxTest/Usb2HcTest.inf
@@ -3,6 +3,7 @@
 #  Copyright 2006 - 2016 Unified EFI, Inc.<BR>
 #  Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -57,6 +58,9 @@
 #  IPF/TimerInterrupt.c
 
 #[sources.Riscv64]
+#  IPF/TimerInterrupt.c
+
+#[sources.LOONGARCH64]
 #  IPF/TimerInterrupt.c
 
 [Packages]

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/UsbHc/BlackBoxTest/LoongArch64/TimerInterrupt.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/UsbHc/BlackBoxTest/LoongArch64/TimerInterrupt.c
@@ -1,0 +1,38 @@
+/** @file
+
+  Copyright 2006 - 2010 Unified EFI, Inc.<BR>
+  Copyright (c) 2010, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+  TimerInterrupt.c
+
+Abstract:
+  Ipf Source file for Mask/Unmask TimerInterrupt.
+
+--*/
+
+#include "UsbHcTest.h"
+
+VOID MaskTimerInterrupt()
+{
+  // TBD
+  return;
+}
+
+VOID UnmaskTimerInterrupt()
+{
+  // TBD
+  return;
+}

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/UsbHc/BlackBoxTest/UsbHcTest.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/UsbHc/BlackBoxTest/UsbHcTest.inf
@@ -3,6 +3,7 @@
 #  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
 #  Copyright (c) 2010 - 2012, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -58,6 +59,9 @@
 
 [sources.RISCV64]
   Riscv64/TimerInterrupt.c
+
+[sources.LOONGARCH64]
+  LoongArch64/TimerInterrupt.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasLib/EntsLib.inf
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasLib/EntsLib.inf
@@ -4,6 +4,7 @@
 #  Copyright (c) 2010 - 2012, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) 2019, ARM Ltd. All rights reserved.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -70,6 +71,10 @@
 [sources.RISCV64]
   Riscv64/EntsLibPlat.h
   Riscv64/InitPlat.c
+
+[sources.LOONGARCH64]
+  LoongArch64/EntsLibPlat.h
+  LoongArch64/InitPlat.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasLib/LoongArch64/EntsLibPlat.h
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasLib/LoongArch64/EntsLibPlat.h
@@ -1,0 +1,56 @@
+/** @file
+
+  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
+  Copyright (c) 2010 - 2012, ARM Ltd. All rights reserved.<BR>
+  Copyright (c) 2021 Hewlett Packard Enterprise Development LP. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  EntsLibPlat.h
+
+Abstract:
+
+  LoongArch64 specific defines
+
+--*/
+
+#ifndef _EFI_LIB_PLAT_H_
+#define _EFI_LIB_PLAT_H_
+
+#define MIN_ALIGNMENT_SIZE  8
+
+VOID
+EntsInitializeLibPlatform (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_SYSTEM_TABLE     *SystemTable
+  )
+/*++
+
+Routine Description:
+
+  Initialize platform.
+
+Arguments:
+
+  ImageHandle           - The image handle.
+  SystemTable           - The system table.
+
+Returns:
+
+  None.
+
+--*/
+;
+
+#endif

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasLib/LoongArch64/InitPlat.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasLib/LoongArch64/InitPlat.c
@@ -1,0 +1,55 @@
+/** @file
+
+  Copyright 2006 - 2012 Unified EFI, Inc.<BR>
+  Copyright (c) 2010 - 2012, ARM Ltd. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  InitPlat.c
+
+Abstract:
+
+  Math routines for compatibility with native EFI library routines.
+
+--*/
+
+#include "Efi.h"
+#include "EntsLibPlat.h"
+
+VOID
+EntsInitializeLibPlatform (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_SYSTEM_TABLE     *SystemTable
+  )
+/*++
+
+Routine Description:
+
+  Initialize platform.
+
+Arguments:
+
+  ImageHandle           - The image handle.
+  SystemTable           - The system table.
+
+Returns:
+
+  None.
+
+--*/
+{
+  //
+  // No platform-specific initializations
+  //
+}

--- a/uefi-sct/SctPkg/Tools/Source/GenBin/GNUmakefile
+++ b/uefi-sct/SctPkg/Tools/Source/GenBin/GNUmakefile
@@ -2,6 +2,7 @@
 #  Copyright 2006 - 2010 Unified EFI, Inc.<BR>
 #  Copyright (c) 2010 Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -34,6 +35,9 @@ ifndef ARCH
   endif
   ifneq (,$(findstring riscv64,$(uname_m)))
     ARCH=RISCV64
+  endif
+  ifneq (,$(findstring loongarch64,$(uname_m)))
+    ARCH=LOONGARCH64
   endif
   ifndef ARCH
     $(info Could not detected ARCH from uname results)

--- a/uefi-sct/SctPkg/UEFI/IHV_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/IHV_SCT.dsc
@@ -4,6 +4,7 @@
 #  Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
 #  Copyright (c) 2019,Microchip Technology Inc.<BR>
 #  (C) Copyright 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -43,7 +44,7 @@
   PLATFORM_VERSION               = 0.1
   DSC_SPECIFICATION              = 0x00010005
   OUTPUT_DIRECTORY               = Build/IhvSct
-  SUPPORTED_ARCHITECTURES        = IA32|X64|ARM|AARCH64|RISCV64
+  SUPPORTED_ARCHITECTURES        = IA32|X64|ARM|AARCH64|RISCV64|LOONGARCH64
   BUILD_TARGETS                  = DEBUG|RELEASE
   SKUID_IDENTIFIER               = DEFAULT
 
@@ -116,6 +117,12 @@
   *_*_RISCV64_APP_FLAGS        = -D EFIRISCV64 $(GCC_VER_MACRO)
   *_*_RISCV64_PP_FLAGS         = -D EFIRISCV64 $(GCC_VER_MACRO)
 
+  *_*_LOONGARCH64_CC_FLAGS     = -D EFILOONGARCH64 $(GCC_VER_MACRO)
+  GCC:*_*_LOONGARCH64_CC_FLAGS = -D EFILOONGARCH64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error
+  *_*_LOONGARCH64_VFRPP_FLAGS  = -D EFILOONGARCH64 $(GCC_VER_MACRO)
+  *_*_LOONGARCH64_APP_FLAGS    = -D EFILOONGARCH64 $(GCC_VER_MACRO)
+  *_*_LOONGARCH64_PP_FLAGS     = -D EFILOONGARCH64 $(GCC_VER_MACRO)
+
   DEBUG_*_*_CC_FLAGS  = -DEFI_DEBUG
   RELEASE_*_*_CC_FLAGS  = -DMDEPKG_NDEBUG
 
@@ -132,6 +139,9 @@
   ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
 [Libraries.RISCV64]
+  ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+
+[Libraries.LOONGARCH64]
   ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
 [Libraries.IA32,Libraries.X64]

--- a/uefi-sct/SctPkg/UEFI/Protocol/DebugSupport.h
+++ b/uefi-sct/SctPkg/UEFI/Protocol/DebugSupport.h
@@ -663,6 +663,98 @@ typedef struct {
 } EFI_SYSTEM_CONTEXT_RISCV64;
 
 //
+// LoongArch processor exception types.
+//
+#define EXCEPT_LOONGARCH_INT   0
+#define EXCEPT_LOONGARCH_PIL   1
+#define EXCEPT_LOONGARCH_PIS   2
+#define EXCEPT_LOONGARCH_PIF   3
+#define EXCEPT_LOONGARCH_PME   4
+#define EXCEPT_LOONGARCH_PNR   5
+#define EXCEPT_LOONGARCH_PNX   6
+#define EXCEPT_LOONGARCH_PPI   7
+#define EXCEPT_LOONGARCH_ADE   8
+#define EXCEPT_LOONGARCH_ALE   9
+#define EXCEPT_LOONGARCH_BCE   10
+#define EXCEPT_LOONGARCH_SYS   11
+#define EXCEPT_LOONGARCH_BRK   12
+#define EXCEPT_LOONGARCH_INE   13
+#define EXCEPT_LOONGARCH_IPE   14
+#define EXCEPT_LOONGARCH_FPD   15
+#define EXCEPT_LOONGARCH_SXD   16
+#define EXCEPT_LOONGARCH_ASXD  17
+#define EXCEPT_LOONGARCH_FPE   18
+#define EXCEPT_LOONGARCH_TBR   64 // For code only, there is no such type in the ISA spec, the TLB refill is defined for an independent exception.
+
+//
+// LoongArch processor Interrupt types.
+//
+#define EXCEPT_LOONGARCH_INT_SIP0   0
+#define EXCEPT_LOONGARCH_INT_SIP1   1
+#define EXCEPT_LOONGARCH_INT_IP0    2
+#define EXCEPT_LOONGARCH_INT_IP1    3
+#define EXCEPT_LOONGARCH_INT_IP2    4
+#define EXCEPT_LOONGARCH_INT_IP3    5
+#define EXCEPT_LOONGARCH_INT_IP4    6
+#define EXCEPT_LOONGARCH_INT_IP5    7
+#define EXCEPT_LOONGARCH_INT_IP6    8
+#define EXCEPT_LOONGARCH_INT_IP7    9
+#define EXCEPT_LOONGARCH_INT_PMC    10
+#define EXCEPT_LOONGARCH_INT_TIMER  11
+#define EXCEPT_LOONGARCH_INT_IPI    12
+
+//
+// For coding convenience, define the maximum valid
+// LoongArch interrupt.
+//
+#define MAX_LOONGARCH_INTERRUPT  14
+
+typedef struct {
+  UINT64    R0;
+  UINT64    R1;
+  UINT64    R2;
+  UINT64    R3;
+  UINT64    R4;
+  UINT64    R5;
+  UINT64    R6;
+  UINT64    R7;
+  UINT64    R8;
+  UINT64    R9;
+  UINT64    R10;
+  UINT64    R11;
+  UINT64    R12;
+  UINT64    R13;
+  UINT64    R14;
+  UINT64    R15;
+  UINT64    R16;
+  UINT64    R17;
+  UINT64    R18;
+  UINT64    R19;
+  UINT64    R20;
+  UINT64    R21;
+  UINT64    R22;
+  UINT64    R23;
+  UINT64    R24;
+  UINT64    R25;
+  UINT64    R26;
+  UINT64    R27;
+  UINT64    R28;
+  UINT64    R29;
+  UINT64    R30;
+  UINT64    R31;
+
+  UINT64    CRMD;  // CuRrent MoDe information
+  UINT64    PRMD;  // PRe-exception MoDe information
+  UINT64    EUEN;  // Extended component Unit ENable
+  UINT64    MISC;  // MISCellaneous controller
+  UINT64    ECFG;  // Exception ConFiGuration
+  UINT64    ESTAT; // Exception STATus
+  UINT64    ERA;   // Exception Return Address
+  UINT64    BADV;  // BAD Virtual address
+  UINT64    BADI;  // BAD Instruction
+} EFI_SYSTEM_CONTEXT_LOONGARCH64;
+
+//
 // Universal EFI_SYSTEM_CONTEXT definition
 //
 typedef
@@ -674,6 +766,7 @@ union {
   EFI_SYSTEM_CONTEXT_ARM                  *SystemContextArm;
   EFI_SYSTEM_CONTEXT_AARCH64              *SystemContextAArch64;
   EFI_SYSTEM_CONTEXT_RISCV64              *SystemContextRiscV64;
+  EFI_SYSTEM_CONTEXT_LOONGARCH64          *SystemContextLoongArch64;
 } EFI_SYSTEM_CONTEXT;
 
 //
@@ -702,6 +795,7 @@ VOID
 #define IMAGE_FILE_MACHINE_ARMTHUMB_MIXED  0x01c2
 #define IMAGE_FILE_MACHINE_ARM64           0xAA64
 #define IMAGE_FILE_MACHINE_RISCV64         0x5064
+#define IMAGE_FILE_MACHINE_LOONGARCH64     0x6264
 
 
 typedef
@@ -710,9 +804,10 @@ enum {
   IsaX64  = IMAGE_FILE_MACHINE_X64,  	
   IsaIpf  = IMAGE_FILE_MACHINE_IA64,
   IsaEbc  = IMAGE_FILE_MACHINE_EBC,
-  IsaArm  = IMAGE_FILE_MACHINE_ARMTHUMB_MIXED, ///< 0x01c2
-  IsaAArch64  = IMAGE_FILE_MACHINE_ARM64,      ///< 0xAA64
-  IsaRiscv64  = IMAGE_FILE_MACHINE_RISCV64     ///< 0x5064
+  IsaArm  = IMAGE_FILE_MACHINE_ARMTHUMB_MIXED,       ///< 0x01c2
+  IsaAArch64  = IMAGE_FILE_MACHINE_ARM64,            ///< 0xAA64
+  IsaRiscv64  = IMAGE_FILE_MACHINE_RISCV64,          ///< 0x5064
+  IsaLoongArch64  = IMAGE_FILE_MACHINE_LOONGARCH64   ///< 0x6264
 } EFI_INSTRUCTION_SET_ARCHITECTURE;
 
 typedef struct _EFI_DEBUG_SUPPORT_PROTOCOL EFI_DEBUG_SUPPORT_PROTOCOL;;

--- a/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
@@ -3,6 +3,7 @@
 #  Copyright 2006 - 2017 Unified EFI, Inc.<BR>
 #  Copyright (c) 2010 - 2018, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2017 - 2021 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -42,7 +43,7 @@
   PLATFORM_VERSION               = 0.1
   DSC_SPECIFICATION              = 0x00010005
   OUTPUT_DIRECTORY               = Build/UefiSct
-  SUPPORTED_ARCHITECTURES        = IA32|X64|ARM|AARCH64|RISCV64
+  SUPPORTED_ARCHITECTURES        = IA32|X64|ARM|AARCH64|RISCV64|LOONGARCH64
   BUILD_TARGETS                  = DEBUG|RELEASE
   SKUID_IDENTIFIER               = DEFAULT
   
@@ -118,6 +119,12 @@
   *_*_RISCV64_APP_FLAGS        = -D EFIRISCV64 $(GCC_VER_MACRO)
   *_*_RISCV64_PP_FLAGS         = -D EFIRISCV64 $(GCC_VER_MACRO)
 
+  *_*_LOONGARCH64_CC_FLAGS         = -D EFILOONGARCH64 $(GCC_VER_MACRO)
+  GCC:*_*_LOONGARCH64_CC_FLAGS     = -D EFILOONGARCH64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error=unused-function -Wno-error=unused-but-set-variable -Wno-error
+  *_*_LOONGARCH64_VFRPP_FLAGS      = -D EFILOONGARCH64 $(GCC_VER_MACRO)
+  *_*_LOONGARCH64_APP_FLAGS        = -D EFILOONGARCH64 $(GCC_VER_MACRO)
+  *_*_LOONGARCH64_PP_FLAGS         = -D EFILOONGARCH64 $(GCC_VER_MACRO)
+
   DEBUG_*_*_CC_FLAGS  = -DEFI_DEBUG
   RELEASE_*_*_CC_FLAGS  = -DMDEPKG_NDEBUG
 
@@ -136,6 +143,9 @@
   ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
 [Libraries.RISCV64]
+  ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+
+[Libraries.LOONGARCH64]
   ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
 !include MdePkg/MdeLibs.dsc.inc
@@ -169,6 +179,9 @@
   NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
 [LibraryClasses.RISCV64]
+  NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+
+[LibraryClasses.LOONGARCH64]
   NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
 
 ###############################################################################

--- a/uefi-sct/SctPkg/build.sh
+++ b/uefi-sct/SctPkg/build.sh
@@ -25,6 +25,8 @@ function get_build_arch
 	        BUILD_ARCH=AARCH64;;
 	    riscv64*)
 	        BUILD_ARCH=RISCV64;;
+	    loongarch64*)
+	        BUILD_ARCH=LOONGARCH64;;
 	    *)
 	        BUILD_ARCH=other;;
 	esac
@@ -55,6 +57,12 @@ function set_cross_compile
 	        TEMP_CROSS_COMPILE="$CROSS_COMPILE_64"
 	    else
 	        TEMP_CROSS_COMPILE=riscv64-unknown-elf-
+	    fi
+	elif [ "$SCT_TARGET_ARCH" == "LOONGARCH64" ]; then
+	    if [ X"$CROSS_COMPILE_64" != X"" ]; then
+	        TEMP_CROSS_COMPILE="$CROSS_COMPILE_64"
+	    else
+	        TEMP_CROSS_COMPILE=loongarch64-unknown-linux-gnu-
 	    fi
 	else
 	    echo "Unsupported target architecture '$SCT_TARGET_ARCH'!" >&2
@@ -119,7 +127,7 @@ PrintUsage() {
 	#Print Help
 	#
 	echo "Usage:"
-	echo "    $0 <architecture (ARM, AARCH64, X64, RISCV64, etc)> \
+	echo "    $0 <architecture (ARM, AARCH64, X64, RISCV64, LOONGARCH64, etc)> \
 <toolchain name (RVCT or ARMGCC or GCC*)> \
 [build type (RELEASE OR DEBUG, DEFAULT: DEBUG)]"
 }


### PR DESCRIPTION
LoongArch64 support was merged into edk2 and edk2-platforms, enable it in edk2-test now.