### PR TITLE
uefi-sct/SctPkg: RouteConfig() returns EFI_ACCESS_DENIED passes with warning

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestFunction.c
@@ -521,7 +521,7 @@ BBTestRouteConfigFunctionTestCheckpoint1 (
                  );
   if ( (EFI_SUCCESS == Status) && (Progress == Resp + SctStrLen (Resp)) ) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
-  } else if ( EFI_OUT_OF_RESOURCES == Status ) {
+  } else if ( (EFI_OUT_OF_RESOURCES == Status) || (EFI_ACCESS_DENIED == Status) ) {
     AssertionType = EFI_TEST_ASSERTION_WARNING;
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigRouting/BlackBoxTest/HIIConfigRoutingBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigRouting/BlackBoxTest/HIIConfigRoutingBBTestFunction.c
@@ -546,7 +546,7 @@ BBTestRouteConfigFunctionTestCheckpoint1 (
 
   if ( (EFI_SUCCESS == Status) && (Progress == Resp2 + SctStrLen (Resp2)) ) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
-  } else if ( EFI_OUT_OF_RESOURCES == Status ){
+  } else if ( (EFI_OUT_OF_RESOURCES == Status) || (EFI_ACCESS_DENIED == Status) ) {
     AssertionType = EFI_TEST_ASSERTION_WARNING;
   } else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3759

HIIConfigAccess and HIIConfigRouting Protocol RouteConfig tests assertions store a failure when RouteConfig returns EFI_ACCESS_DENIED. In the UEFI SPEC RouteConfig in both protocols can return EFI_ACCESS_DENIED when the action violates a system policy. The tests now record a pass with warning.

Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Cc: Carolyn Gjertsen <Carolyn.Gjertsen@amd.com>
Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Cc: Sunny Wang <Sunny.Wang@arm.com>

Reviewed-by: Sunny Wang <sunny.wang@arm.com>
Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>

Change-Id: I8591c3d7b0855133141779d3c53a159129400815