### PR TITLE
SctPkg: Fixed a pinter error in DevicePathFromTextBBTestCoverage.c

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathFromText/BlackBoxTest/DevicePathFromTextBBTestCoverage.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathFromText/BlackBoxTest/DevicePathFromTextBBTestCoverage.c
@@ -1734,13 +1734,13 @@ CreateDNSDeviceNode (
   }
 
   if (DNS->IsIPv6 == 0) {
-    SctStrToIPv4Addr (&IpStr1, (EFI_IPv4_ADDRESS *)(DNS + sizeof (DNS_DEVICE_PATH)));
-    SctStrToIPv4Addr (&IpStr2, (EFI_IPv4_ADDRESS *)(DNS + sizeof (DNS_DEVICE_PATH) + sizeof(EFI_IP_ADDRESS)));
+    SctStrToIPv4Addr (&IpStr1, (EFI_IPv4_ADDRESS *)((UINT8 *)DNS + sizeof (DNS_DEVICE_PATH)));
+    SctStrToIPv4Addr (&IpStr2, (EFI_IPv4_ADDRESS *)((UINT8 *)DNS + sizeof (DNS_DEVICE_PATH) + sizeof(EFI_IP_ADDRESS)));
   }
 
   if (DNS->IsIPv6 == 1) {
-    SctStrToIPv6Addr (&IpStr1, (EFI_IPv6_ADDRESS *)(DNS + sizeof (DNS_DEVICE_PATH)));
-    SctStrToIPv6Addr (&IpStr2, (EFI_IPv6_ADDRESS *)(DNS + sizeof (DNS_DEVICE_PATH) + sizeof(EFI_IP_ADDRESS)));
+    SctStrToIPv6Addr (&IpStr1, (EFI_IPv6_ADDRESS *)((UINT8 *)DNS + sizeof (DNS_DEVICE_PATH)));
+    SctStrToIPv6Addr (&IpStr2, (EFI_IPv6_ADDRESS *)((UINT8 *)DNS + sizeof (DNS_DEVICE_PATH) + sizeof(EFI_IP_ADDRESS)));
   }
 
   return (EFI_DEVICE_PATH_PROTOCOL *) DNS;


### PR DESCRIPTION
DevicePathFromTextBBTextCoverage.c function CreateDNSDeviceNode has a bug, code:

SctStrToIPv4Addr (&IpStr1, (EFI_IPv4_ADDRESS *)(DNS + sizeof (DNS_DEVICE_PATH)));

DNS is a pointer, which is increased by a structure size and converted to EFI_IPv4_ADDRESS*, which will point to an unknown address. So fix it.

Fixes: 847e0363e846 ("SctPkg: Fix the UefiSct-Wincompatible-pointer-types warnings")

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4712

Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Cc: Carolyn Gjertsen <Carolyn.Gjertsen@amd.com>
Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Cc: Eric Jin <eric.jin@intel.com>
Cc: Arvin Chen <arvinx.chen@intel.com>
Cc: Supreeth Venkatesh <Supreeth.Venkatesh@amd.com>
Cc: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>

Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>