### PR TITLE
uefi-sct/SctPkg:Enhance BBTestReadKeyStrokeExFunctionAutoTestCheckpoint1()

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestFunction.c
@@ -1175,6 +1175,12 @@ BBTestReadKeyStrokeExFunctionAutoTestCheckpoint1 (
   ValidState[6] = EFI_TOGGLE_STATE_VALID | EFI_KEY_STATE_EXPOSED | EFI_SCROLL_LOCK_ACTIVE |EFI_NUM_LOCK_ACTIVE | EFI_CAPS_LOCK_ACTIVE;
 
   //
+  // Set all bits to one (invalid values) for both KeyShiftState and KeyToggleState
+  //
+  Key.KeyState.KeyShiftState = 0xFFFFFFFF;
+  Key.KeyState.KeyToggleState = 0xFF;
+
+  //
   //Read next keystroke from the input device
   //
   Status = SimpleTextInputEx->ReadKeyStrokeEx (
@@ -1185,7 +1191,10 @@ BBTestReadKeyStrokeExFunctionAutoTestCheckpoint1 (
     return Status;
   }
 
-  if ((Key.KeyState.KeyToggleState & EFI_TOGGLE_STATE_VALID) == 0) {
+  if (((Key.KeyState.KeyToggleState & EFI_TOGGLE_STATE_VALID) == 0) || (Key.KeyState.KeyShiftState == 0xFFFFFFFF) || (Key.KeyState.KeyToggleState == 0xFF)) {
+    //
+    // Log the error here and return key states are not supported when high order bit of KeyToggleState is 0 or KeyState not touched
+    //
     return EFI_UNSUPPORTED;
   }
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestFunction.c
@@ -1161,6 +1161,12 @@ BBTestReadKeyStrokeExFunctionAutoTestCheckpoint1 (
   ValidState[6] = EFI_TOGGLE_STATE_VALID | EFI_KEY_STATE_EXPOSED | EFI_SCROLL_LOCK_ACTIVE |EFI_NUM_LOCK_ACTIVE | EFI_CAPS_LOCK_ACTIVE;
 
   //
+  // Set all bits to one (invalid values) for both KeyShiftState and KeyToggleState
+  //
+  Key.KeyState.KeyShiftState = 0xFFFFFFFF;
+  Key.KeyState.KeyToggleState = 0xFF;
+
+  //
   //Read next keystroke from the input device
   //
   Status = SimpleTextInputEx->ReadKeyStrokeEx (
@@ -1171,7 +1177,10 @@ BBTestReadKeyStrokeExFunctionAutoTestCheckpoint1 (
     return Status;
   }
 
-  if ((Key.KeyState.KeyToggleState & EFI_TOGGLE_STATE_VALID) == 0) {
+  if (((Key.KeyState.KeyToggleState & EFI_TOGGLE_STATE_VALID) == 0) || (Key.KeyState.KeyShiftState == 0xFFFFFFFF) || (Key.KeyState.KeyToggleState == 0xFF)) {
+    //
+    // Log the error here and return key states are not supported when high order bit of KeyToggleState is 0 or KeyState not touched
+    //
     return EFI_UNSUPPORTED;
   }
 


### PR DESCRIPTION
REF:  https://bugzilla.tianocore.org/show_bug.cgi?id=2386

Enhance BBTestReadKeyStrokeExFunctionAutoTestCheckpoint1() to handle ReadKeyStrokeEx implementation which returns EFI_NOT_READY but without touching KeyToggleState.

Signed-off-by: Barton Gao <gaojie@byosoft.com.cn>

Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>
Reviewed-by: Sunny Wang <sunny.wang@arm.com>