### PR TITLE
Build cleanup

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTest.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTest.h
@@ -79,7 +79,6 @@ typedef struct {
   UINT8  buffer[TEST_STRING_LEN];
 } TPM2B_MAX_BUFFER;
 
-#pragma pack(1)
 // TPM2B_DIGEST as defined in Table 73 of TPM Library Spec Part 2: Structures
 typedef struct {
   UINT16 size;
@@ -110,7 +109,7 @@ typedef struct {
   TPM2B_DIGEST data;
   TPMT_TK_HASHCHECK validation;
 } TPM2_HASH_RESPONSE;
-#pragma
+#pragma pack()
 
 EFI_STATUS
 EFIAPI

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
@@ -639,7 +639,7 @@ BBTestHashLogExtendEventConformanceTestCheckpoint1 (
   EFI_TCG2_EVENT                        *EfiTcgEvent;
   const CHAR8                           *EventData = "TCG2 Protocol Test";
   const CHAR8                           *Str = "The quick brown fox jumps over the lazy dog";
-  UINT32                                EfiTcgEventSize = sizeof(EFI_TCG2_EVENT) + SctAsciiStrLen(EventData);
+  UINT32                                EfiTcgEventSize = (UINT32)(sizeof(EFI_TCG2_EVENT) + SctAsciiStrLen(EventData));
 
   DataToHash =  (EFI_PHYSICAL_ADDRESS)Str;
   DataToHashLen = SctAsciiStrLen(Str);
@@ -654,7 +654,7 @@ BBTestHashLogExtendEventConformanceTestCheckpoint1 (
   EfiTcgEvent->Header.HeaderVersion = 1;
   EfiTcgEvent->Header.EventType = EV_POST_CODE;
   EfiTcgEvent->Header.PCRIndex = 16;
-  EfiTcgEvent->Size = EfiTcgEvent->Header.HeaderSize + SctAsciiStrLen(EventData);
+  EfiTcgEvent->Size = EfiTcgEvent->Header.HeaderSize + (UINT32)SctAsciiStrLen(EventData);
 
   // Ensure HashLogExtendEvent returns Invalid Parameter when passing in NULL DataToHash pointer
   // EFI Protocol Spec Section 6.6.5 #1
@@ -710,7 +710,7 @@ BBTestHashLogExtendEventConformanceTestCheckpoint1 (
 
   // Ensure HashLogExtendEvent returns Invalid Parameter when passed in EventSize < HeaderSize + sizeof(UINT32)
   // EFI Protocol Spec Section 6.6.5 #2
-  EfiTcgEvent->Size = EfiTcgEvent->Header.HeaderSize + sizeof(UINT32) - 1;
+  EfiTcgEvent->Size = EfiTcgEvent->Header.HeaderSize + (UINT32)sizeof(UINT32) - 1;
 
   Status = TCG2->HashLogExtendEvent (
                            TCG2,
@@ -739,7 +739,7 @@ BBTestHashLogExtendEventConformanceTestCheckpoint1 (
   // Ensure HashLogExtendEvent returns Invalid Parameter when passing in PCR Index > 23
   // EFI Protocol Spec Section 6.6.5 #3
   EfiTcgEvent->Header.PCRIndex = 24;
-  EfiTcgEvent->Size = EfiTcgEvent->Header.HeaderSize + SctAsciiStrLen(EventData);
+  EfiTcgEvent->Size = EfiTcgEvent->Header.HeaderSize + (UINT32)SctAsciiStrLen(EventData);
 
   Status = TCG2->HashLogExtendEvent (
                            TCG2,
@@ -782,7 +782,7 @@ BBTestHashLogExtendEventConformanceTestCheckpoint2 (
   UINT64                                DataToHashLen;
   const CHAR8                           *Str = "The quick brown fox jumps over the lazy dog";
   const CHAR8                           *EventData = "TCG2 Protocol Test";
-  UINT32 EfiTcgEventSize = sizeof(EFI_TCG2_EVENT) + SctAsciiStrLen(EventData);
+  UINT32 EfiTcgEventSize = (UINT32)(sizeof(EFI_TCG2_EVENT) + SctAsciiStrLen(EventData));
 
   DataToHash = (EFI_PHYSICAL_ADDRESS)Str;
   DataToHashLen = SctAsciiStrLen(Str);
@@ -797,7 +797,7 @@ BBTestHashLogExtendEventConformanceTestCheckpoint2 (
   EfiTcgEvent->Header.HeaderVersion = 1;
   EfiTcgEvent->Header.EventType = EV_POST_CODE;
   EfiTcgEvent->Header.PCRIndex = 16;
-  EfiTcgEvent->Size = EfiTcgEvent->Header.HeaderSize + SctAsciiStrLen(EventData);
+  EfiTcgEvent->Size = EfiTcgEvent->Header.HeaderSize + (UINT32)SctAsciiStrLen(EventData);
 
   // Perform HashLogExtendEvent over test buffer to PCR 16
   Status = TCG2->HashLogExtendEvent (
@@ -991,9 +991,7 @@ BBTestGetEventLogConformanceTestCheckpoint2 (
   }
 
   // Verify EventLog Signature
-  Status = SctCompareMem(EventLogHeaderSpecEvent->signature, signature, sizeof(signature));
-
-  if (Status != EFI_SUCCESS) {
+  if (SctCompareMem(EventLogHeaderSpecEvent->signature, signature, sizeof(signature) != 0)) {
     StandardLib->RecordMessage (
                      StandardLib,
                      EFI_VERBOSE_LEVEL_DEFAULT,
@@ -1076,7 +1074,7 @@ BBTestSubmitCommandConformanceTestCheckpoint1 (
   CommandInput.Tag = SctSwapBytes16(ST_NO_SESSIONS);
   CommandInput.CommandSize = SctSwapBytes32(sizeof(TPM2_HASH_COMMAND));
   CommandInput.CommandCode = SctSwapBytes32(TPM_CC_Hash);
-  CommandInput.data.size = SctSwapBytes16(SctAsciiStrLen(Str));
+  CommandInput.data.size = SctSwapBytes16((UINT16)SctAsciiStrLen(Str));
   SctAsciiStrCpy((CHAR8 *)CommandInput.data.buffer, Str);
   CommandInput.hashAlg = SctSwapBytes16(TPM_ALG_SHA256);
   CommandInput.hierarchy = SctSwapBytes32(TPM_RH_NULL);

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
@@ -25,8 +25,7 @@ Abstract:
 --*/
 
 #include "TCG2ProtocolBBTest.h"
-
-#define offsetof(st, m) __builtin_offsetof(st, m)
+#include <Base.h>
 
 /**
  *  @brief Entrypoint for GetCapability() Function Test.
@@ -475,7 +474,7 @@ BBTestGetCapabilityConformanceTestCheckpoint4 (
 
   // set size of struct to be up to and including the ManufacturerID
   // (this acts like a client with a 1.0 version of the struct)
-  BootServiceCap.Size = offsetof(EFI_TCG2_BOOT_SERVICE_CAPABILITY, NumberOfPcrBanks);
+  BootServiceCap.Size = OFFSET_OF(EFI_TCG2_BOOT_SERVICE_CAPABILITY, NumberOfPcrBanks);
 
   Status = TCG2->GetCapability (
                            TCG2,
@@ -494,7 +493,7 @@ BBTestGetCapabilityConformanceTestCheckpoint4 (
   }
 
   // Verify returned Size equals the size of EFI_TCG2_BOOT_SERVICE_CAPABILITY up to and including the ManufacturerID field.
-  if (BootServiceCap.Size != offsetof(EFI_TCG2_BOOT_SERVICE_CAPABILITY, NumberOfPcrBanks)) {
+  if (BootServiceCap.Size != OFFSET_OF(EFI_TCG2_BOOT_SERVICE_CAPABILITY, NumberOfPcrBanks)) {
     StandardLib->RecordMessage (
                      StandardLib,
                      EFI_VERBOSE_LEVEL_DEFAULT,

--- a/uefi-sct/SctPkg/UEFI/Protocol/TCG2.h
+++ b/uefi-sct/SctPkg/UEFI/Protocol/TCG2.h
@@ -50,7 +50,12 @@ Abstract:
 
 #define EFI_TCG2_EVENT_LOG_FORMAT_TCG_2 0x00000002
 
-#define HASH_NUMBER 0x04
+#define HASH_NUMBER 0x05
+#define SHA1_DIGEST_SIZE    20
+#define SHA256_DIGEST_SIZE  32
+#define SHA384_DIGEST_SIZE  48
+#define SHA512_DIGEST_SIZE  64
+#define SM3_256_DIGEST_SIZE 32
 
 typedef struct _EFI_TCG2_PROTOCOL EFI_TCG2_PROTOCOL;
 
@@ -117,9 +122,17 @@ typedef struct tdEFI_TCG2_EVENT {
   UINT8 Event[];
 } EFI_TCG2_EVENT;
 
+typedef union {
+  UINT8 sha1[SHA1_DIGEST_SIZE];
+  UINT8 sha256[SHA256_DIGEST_SIZE];
+  UINT8 sm3_256[SM3_256_DIGEST_SIZE];
+  UINT8 sha384[SHA384_DIGEST_SIZE];
+  UINT8 sha512[SHA512_DIGEST_SIZE];
+} TPMU_HA;
+
 typedef struct {
   UINT16     hashAlg;
-  UINT8      digest[];
+  TPMU_HA    digest;
 } TPMT_HA;
 
 typedef struct tdTPML_DIGEST_VALUES {


### PR DESCRIPTION
This patch series cleans up some issues found when building edk2-test with a non-GCC compiler:
  -TPMT_HA struct had an error due to incorrect use of C flexible array member
  -compute struct member offsets using OFFSET_OF, which is not GCC specific
  -clean up of #pragma pack in one file
  -resolve type conversion warnings

Patches are in github here:
https://github.com/stuyod01/edk2-test/tree/tcg2-cleanup

Version 2
  -add SM3 hash type to TPM2.h
  -resolve type conversion warnings