### PR TITLE
Fix build with gcc 14

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestConformance.c
@@ -21,6 +21,7 @@ Abstract:
     for EFI Adapter Information Protocol's conformance Test
 
 --*/
+#include "SctLib.h"
 #include "AdapterInfoBBTestMain.h"
 
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestFunction.c
@@ -21,6 +21,7 @@ Abstract:
     for EFI Adapter Information Protocol's function Test
 
 --*/
+#include "SctLib.h"
 #include "AdapterInfoBBTestMain.h"
 
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestMain.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestMain.c
@@ -24,6 +24,7 @@ Abstract:
 
 --*/
 
+#include "SctLib.h"
 #include "AdapterInfoBBTestMain.h"
 
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestMain.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestMain.h
@@ -160,12 +160,4 @@ BBTestGetSupportedTypesFunctionTest (
   IN EFI_HANDLE                 SupportHandle
   );
 
-
-VOID
-SctInitializeLib (
-  IN EFI_HANDLE                 ImageHandle,
-  IN EFI_SYSTEM_TABLE           *SystemTable
-  );
-
-
 #endif


### PR DESCRIPTION
When building with gcc-14, we will meet the problems like:

error: implicit declaration of function ‘SctDevicePathStrFromProtocol’ [-Wimplicit-function-declaration]