### PR TITLE
uefi-sct: Increase the waiting time in the SCT GetStatus_Func test

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
@@ -1870,7 +1870,7 @@ BBTestGetStatusFunctionTest (
     StatCode = gtBS->SetTimer (
                        TimeoutEvent,
                        TimerRelative,
-                       50000);  /* 5 milliseconds */
+                       5000000);  /* 500 milliseconds. This value is increased from old value 5 milliseconds to due false positives on some platforms */
     if (EFI_ERROR(StatCode)) {
       StandardLib->RecordAssertion (
                      StandardLib,
@@ -2196,7 +2196,7 @@ BBTestTransmitFunctionTest (
     StatCode = gtBS->SetTimer (
         TimeoutEvent,
         TimerRelative,
-        50000);  /* 5 milliseconds */
+        5000000);  /* 500 milliseconds. This value is increased from old value 5 milliseconds to due false positives on some platforms */
     if (EFI_ERROR(StatCode)) {
       StandardLib->RecordAssertion (
                      StandardLib,


### PR DESCRIPTION
The current time delay in the SCT GetStatus_Func test is 5 milliseconds, which caused false positives with some platforms This time delay is increased to 500 miliseconds with reference to similar values in https://github.com/tianocore/edk2/blob/master/NetworkPkg/Include/Library/NetLib.h#L265

Signed-off-by: G Edhaya Chandran <edhaya.chandran@arm.com>
Co-authored-by: Sunny Wang <sunny.wang@arm.com>

Reviewed-by: Sunny Wang <sunny.wang@arm.com>
Reviewed-by: Stuart Yoder <stuart.yoder@arm.com>