### PR TITLE
uefi-sct/SctPkg: ExtractConfig allows EFI_ACCESS_DENIED with a warning

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestFunction.c
@@ -328,7 +328,8 @@ BBTestExtractConfigFunctionTestCheckpoint1 (
     } else {
       gtBS->FreePool (Results);
     }
-  } else if (EFI_OUT_OF_RESOURCES == Status) {
+  } else if ( (EFI_OUT_OF_RESOURCES == Status) ||
+    (EFI_ACCESS_DENIED == Status) ) {
     AssertionType = EFI_TEST_ASSERTION_WARNING;  
   }else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -385,7 +386,8 @@ BBTestExtractConfigFunctionTestCheckpoint1 (
       }
       gtBS->FreePool (Results);
     }
-  } else if (EFI_OUT_OF_RESOURCES == Status) {
+  } else if ( (EFI_OUT_OF_RESOURCES == Status) ||
+    (EFI_ACCESS_DENIED == Status) ) {
     AssertionType = EFI_TEST_ASSERTION_WARNING;  
   }else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4847

EFI_ACCESS_DENIED (The action violated a system policy) is an acceptable status for ExtractConfig in UEFI specification. SCT now makrs the test case as a warning instead of failure, when EFI_ACCESS_DENIED is returned.

Signed-off-by: Ann Cheng <ann.cheng@arm.com>