### PR TITLE
test: AB#1416901 Add RT properties table test to open source SCT

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTest_uefi.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTest_uefi.inf
@@ -51,6 +51,10 @@
   UefiDriverEntryPoint
   SctLib
   EfiTestLib
+  UefiLib
+
+[Guids]
+  gEfiRtPropertiesTableGuid
 
 [Protocols]
   gEfiDebugPortProtocolGuid


### PR DESCRIPTION
Adds tests to verify the EFI RT Properties Table installation and RuntimeServicesSupported variable validity.

The EFI_RT_PROPERTIES_TABLE is defined in section 4.6 EFI Configuration Table & Properties Table in the UEFI Spec 2.8 Errata C document.

- [x] PR title is of the form `<type>: <id> <change description>`
  - Types: `build`, `ci`, `docs`, `feat`, `bugfix`, `test`
  - ID formats: `SIO123`, see wiki for Azure Board format
  - More info: https://rndwiki.inc.hpicorp.net/confluence/display/PMO/Git+Commit+Message+Guidelines

**Related IDs**
 
- Feature: AB#1394660 EDK2 v2.8
- Story: AB#1416901 Add RT properties table test to open source SCT
- Bug:
