### PR TITLE
uefi-sct: Add EFI RT Properties Table tests

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestRequired_uefi.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestRequired_uefi.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024 HP Development Company, L.P. <BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -29,6 +30,8 @@ Abstract:
 //
 
 #include "SctLib.h"
+#include <Library/UefiLib.h>
+#include <Guid/RtPropertiesTable.h>
 #include "EfiCompliantBbTestMain_uefi.h"
 #include EFI_PROTOCOL_DEFINITION (LoadedImage)
 #include EFI_PROTOCOL_DEFINITION (DevicePath)
@@ -39,6 +42,11 @@ EFI_GUID gGlobalVariableGuid = EFI_GLOBAL_VARIABLE;
 
 #define  GlobalVariableNum    40
 #define  MAX_BUFFER_SIZE      1024
+
+typedef struct _RUNTIME_SERVICE_CHECK {
+  VOID      *Function;
+  UINT32    Flag;
+} RUNTIME_SERVICE_CHECK;
 
 typedef struct _VARIABLE_PAIR {
   CHAR16    Name[30];
@@ -104,6 +112,11 @@ CheckBootServices (
 
 EFI_STATUS
 CheckRuntimeServices (
+  IN EFI_STANDARD_TEST_LIBRARY_PROTOCOL   *StandardLib
+  );
+
+EFI_STATUS
+CheckRuntimePropertiesTable (
   IN EFI_STANDARD_TEST_LIBRARY_PROTOCOL   *StandardLib
   );
 
@@ -182,6 +195,11 @@ Routine Description:
   // Check the EFI Runtime Services
   //
   CheckRuntimeServices (StandardLib);
+
+  //
+  // Check the EFI Runtime Properties Table
+  //
+  CheckRuntimePropertiesTable (StandardLib);
 
   //
   // Check the LOADED_IMAGE Protocol
@@ -708,6 +726,101 @@ CheckRuntimeServices (
                    L"  UpdateCapsule             : Not available\n"
                    );
   }
+  //
+  // Done
+  //
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+CheckRuntimePropertiesTable (
+  IN EFI_STANDARD_TEST_LIBRARY_PROTOCOL   *StandardLib
+  )
+{
+  EFI_TEST_ASSERTION       AssertionType;
+  EFI_RT_PROPERTIES_TABLE  *RtPropertiesTable               = NULL;
+  UINT32                   ExpectedRuntimeServicesSupported = 0u;
+  EFI_STATUS               Status                           = EFI_NOT_STARTED;
+
+  RUNTIME_SERVICE_CHECK    RuntimeServices[] = {
+    { (VOID *)gtRT->GetTime, EFI_RT_SUPPORTED_GET_TIME },
+    { (VOID *)gtRT->SetTime, EFI_RT_SUPPORTED_SET_TIME },
+    { (VOID *)gtRT->GetWakeupTime, EFI_RT_SUPPORTED_GET_WAKEUP_TIME },
+    { (VOID *)gtRT->SetWakeupTime, EFI_RT_SUPPORTED_SET_WAKEUP_TIME },
+    { (VOID *)gtRT->GetVariable, EFI_RT_SUPPORTED_GET_VARIABLE },
+    { (VOID *)gtRT->GetNextVariableName, EFI_RT_SUPPORTED_GET_NEXT_VARIABLE_NAME },
+    { (VOID *)gtRT->SetVariable, EFI_RT_SUPPORTED_SET_VARIABLE },
+    { (VOID *)gtRT->SetVirtualAddressMap, EFI_RT_SUPPORTED_SET_VIRTUAL_ADDRESS_MAP },
+    { (VOID *)gtRT->ConvertPointer, EFI_RT_SUPPORTED_CONVERT_POINTER },
+    { (VOID *)gtRT->GetNextHighMonotonicCount, EFI_RT_SUPPORTED_GET_NEXT_HIGH_MONOTONIC_COUNT },
+    { (VOID *)gtRT->ResetSystem, EFI_RT_SUPPORTED_RESET_SYSTEM },
+    { (VOID *)gtRT->UpdateCapsule, EFI_RT_SUPPORTED_UPDATE_CAPSULE },
+    { (VOID *)gtRT->QueryCapsuleCapabilities, EFI_RT_SUPPORTED_QUERY_CAPSULE_CAPABILITIES },
+    { (VOID *)gtRT->QueryVariableInfo, EFI_RT_SUPPORTED_QUERY_VARIABLE_INFO }
+  };
+
+  //
+  // Check the EFI Runtime Services Table
+  //
+  Status = EfiGetSystemConfigurationTable (&gEfiRtPropertiesTableGuid, (VOID **)&RtPropertiesTable);
+  if (EFI_ERROR (Status)) {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gEfiCompliantBbTestRequiredAssertionGuid010,
+                 L"UEFI Compliant - EFI Runtime Properties Table must be implemented",
+                 L"%a:%d:Status - %r, Expected - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status,
+                 EFI_SUCCESS
+                 );
+
+  //
+  // Record the entire EFI Runtime Properties Table
+  //
+  StandardLib->RecordMessage (
+                 StandardLib,
+                 EFI_VERBOSE_LEVEL_DEFAULT,
+                 L"  Version                  : %X\n"
+                 L"  Length                   : %X\n"
+                 L"  RuntimeServicesSupported : %X\n",
+                 RtPropertiesTable->Version,
+                 RtPropertiesTable->Length,
+                 RtPropertiesTable->RuntimeServicesSupported
+                 );
+
+  //
+  // Check RuntimeServicesSupported variable introduced by UEFI spec
+  //
+  for (int i = 0; i < sizeof(RuntimeServices) / sizeof(RuntimeServices[0]); i++) {
+    if (RuntimeServices[i].Function != NULL) {
+      ExpectedRuntimeServicesSupported |= RuntimeServices[i].Flag;
+    }
+  }
+
+  if (RtPropertiesTable->RuntimeServicesSupported == ExpectedRuntimeServicesSupported) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gEfiCompliantBbTestRequiredAssertionGuid010,
+                 L"UEFI Compliant - EFI Runtime Properties Table RuntimeServicesSupported variable must be implemented",
+                 L"%a:%d:RuntimeServicesSupported - 0x%x, Expected - 0x%x",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 RtPropertiesTable->RuntimeServicesSupported,
+                 ExpectedRuntimeServicesSupported
+                 );
   //
   // Done
   //

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTest_uefi.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTest_uefi.inf
@@ -2,6 +2,7 @@
 #
 #  Copyright 2006 - 2016 Unified EFI, Inc.<BR>
 #  Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) 2024 HP Development Company, L.P. <BR>
 #
 #  This program and the accompanying materials
 #  are licensed and made available under the terms and conditions of the BSD License
@@ -51,6 +52,10 @@
   UefiDriverEntryPoint
   SctLib
   EfiTestLib
+  UefiLib
+
+[Guids]
+  gEfiRtPropertiesTableGuid
 
 [Protocols]
   gEfiDebugPortProtocolGuid

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/Guid_uefi.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/Guid_uefi.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024 HP Development Company, L.P. <BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -99,3 +100,5 @@ EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid006 = EFI_TEST_EFICOMPLIANTBBTE
 EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid008 = EFI_TEST_EFICOMPLIANTBBTESTREQUIRED_ASSERTION_008_GUID;
 
 EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid009 = EFI_TEST_EFICOMPLIANTBBTESTREQUIRED_ASSERTION_009_GUID;
+
+EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid010 = EFI_TEST_EFICOMPLIANTBBTESTREQUIRED_ASSERTION_010_GUID;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/Guid_uefi.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/Guid_uefi.h
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024 HP Development Company, L.P. <BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -204,4 +205,9 @@ extern EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid008;
 { 0xf6334f9b, 0xb930, 0x4adb, {0xa5, 0x3b, 0x76, 0xfa, 0x7b, 0x4c, 0x27, 0x62 }}
 
 extern EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid009;
+
+#define EFI_TEST_EFICOMPLIANTBBTESTREQUIRED_ASSERTION_010_GUID \
+{ 0xe6c7861f, 0x350e, 0x4a4c, {0xbe, 0x57, 0xcb, 0xde, 0xfd, 0xbb, 0x56, 0x89 }}
+
+extern EFI_GUID gEfiCompliantBbTestRequiredAssertionGuid010;
 


### PR DESCRIPTION
This patch adds tests to verify the EFI RT Properties Table installation and RuntimeServicesSupported variable validity.

The EFI_RT_PROPERTIES_TABLE is defined in section 4.6 EFI Configuration Table & Properties Table in the UEFI Spec 2.8 Errata C document.

Signed-off-by: Ronal Hernandez <ronal.hernandez1@hp.com>

Reviewed-by: Anbazhagan, Baraneedharan <anbazhagan@hp.com>
Reviewed-by: Phan, Christine <christine.phan@hp.com>