### PR TITLE
uefi-sct/SctPkg: ExtractConfig allows EFI_ACCESS_DENIED with a warning

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestFunction.c
@@ -328,8 +328,8 @@ BBTestExtractConfigFunctionTestCheckpoint1 (
     } else {
       gtBS->FreePool (Results);
     }
-  } else if (EFI_OUT_OF_RESOURCES == Status) {
-    AssertionType = EFI_TEST_ASSERTION_WARNING;  
+  } else if ( (EFI_OUT_OF_RESOURCES == Status) || (EFI_ACCESS_DENIED == Status) ) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
   }else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
@@ -385,7 +385,7 @@ BBTestExtractConfigFunctionTestCheckpoint1 (
       }
       gtBS->FreePool (Results);
     }
-  } else if (EFI_OUT_OF_RESOURCES == Status) {
+  } else if ( (EFI_OUT_OF_RESOURCES == Status) || (EFI_ACCESS_DENIED == Status) ) {
     AssertionType = EFI_TEST_ASSERTION_WARNING;  
   }else {
     AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -445,7 +445,7 @@ BBTestExtractConfigFunctionTestCheckpoint2 (
                   &Results
                   );
 
-  if (EFI_OUT_OF_RESOURCES == Status) {
+  if ( (EFI_OUT_OF_RESOURCES == Status) || (EFI_ACCESS_DENIED == Status) ) {
     AssertionType = EFI_TEST_ASSERTION_WARNING;
   } else if ((EFI_NOT_FOUND == Status) && (Progress == NULL) && (Results == NULL)) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;


### PR DESCRIPTION
REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4847

EFI_ACCESS_DENIED (The action violated a system policy) is an acceptable status for ExtractConfig in UEFI specification.

SCT now marks the test case as a warning instead of failure, when EFI_ACCESS_DENIED is returned.

Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Cc: Carolyn Gjertsen <Carolyn.Gjertsen@amd.com>

Reviewed-by: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Reviewed-by: Sunny Wang <Sunny.Wang@arm.com>

