### PR TITLE
edk2-test: uefi-sct: Correct the vlanId check in DevicePath Test

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePath/BlackBoxTest/DevicePathBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePath/BlackBoxTest/DevicePathBBTestFunction.c
@@ -682,7 +682,7 @@ BBTestDevicePathNodeConformanceAutoTest (
     //
     else if ((Type == 3) && (SubType == 20)) {
       Vlan = (VLAN_DEVICE_PATH *) DevicePath;
-      if (Vlan->VlanId > 4094 || Vlan->VlanId) {
+      if (Vlan->VlanId > 4094 || Vlan->VlanId < 1) {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
       } else {
         AssertionType = EFI_TEST_ASSERTION_PASSED;


### PR DESCRIPTION
The DevicePathBBTest wrongly flags the failure for a valid VLAN device path node. For e.g. value 4040
The range check for vlanId is corrected to fix this issue.

https://bugzilla.tianocore.org/show_bug.cgi?id=4710

Signed-off-by: G Edhaya Chandran <edhaya.chandran@arm.com>

Reviewed-by: Sunny Wang <sunny.wang@arm.com>
Reviewed-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>