### PR TITLE
uefi-sct/SctPkg: TCG2 Protocol: Expand BSCap.HashAlgorithmBitmap check

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
@@ -1,7 +1,7 @@
 /** @file
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
-  Copyright (c) 2021 - 2023, Arm Inc. All rights reserved.<BR>
+  Copyright (c) 2021 - 2023, 2025 Arm Inc. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -346,7 +346,10 @@ BBTestGetCapabilityConformanceTestCheckpoint2 (
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   }
 
-  if (!(BootServiceCap.HashAlgorithmBitmap & EFI_TCG2_BOOT_HASH_ALG_SHA256)) {
+  // Verify if system supports SHA256, SHA384, or SHA512 hashing algorithm
+  EFI_TCG2_EVENT_ALGORITHM_BITMAP HashAlgoSupportBitmap = EFI_TCG2_BOOT_HASH_ALG_SHA256 | EFI_TCG2_BOOT_HASH_ALG_SHA384 | EFI_TCG2_BOOT_HASH_ALG_SHA512;
+
+  if (!(BootServiceCap.HashAlgorithmBitmap & HashAlgoSupportBitmap)) {
     StandardLib->RecordMessage (
                      StandardLib,
                      EFI_VERBOSE_LEVEL_DEFAULT,


### PR DESCRIPTION
Previously, the test only validated SHA-256 in EFI_TCG2_BOOT_SERVICE_CAPABILITY.HashAlgorithmBitmap, This update checks all supported SHA256-or-stronger algorithms.

Signed-off-by: Amrathesh <amrathesh@arm.com>

Reviewed-by: Stuart Yoder <stuart.yoder@arm.com>
Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>