### PR TITLE
edk2-test: uefi-sct: Correct the AIP GUID gEfiAdapterInfoUndiIPv6SupportGuid definition.

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/AdapterInfo/BlackBoxTest/Guid.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/AdapterInfo/BlackBoxTest/Guid.c
@@ -61,7 +61,7 @@ EFI_GUID gEfiAdapterInfoSanMacAddressGuid           = EFI_ADAPTER_INFO_SAN_MAC_A
 
 EFI_GUID gEfiAdapterInfoNetworkBootGuid             = EFI_ADAPTER_INFO_NETWORK_BOOT_GUID;
 
-EFI_GUID gEfiAdapterInfoUndiIPv6SupportGuid         = EFI_ADAPTER_INFO_NETWORK_BOOT_GUID;
+EFI_GUID gEfiAdapterInfoUndiIPv6SupportGuid         = EFI_ADAPTER_INFO_UNDI_IPV6_SUPPORT_GUID;
 
 EFI_GUID gEfiAdapterInfoMediaTypeGuid               = EFI_ADAPTER_INFO_MEDIA_TYPE_GUID;
 


### PR DESCRIPTION
The EFI_ADAPTER_INFORMATION_PROTOCOL Test 5.5.11.1.2 always FAILS with the AIP Support Type gEfiAdapterInfoNetworkBootGuid.

In the Guid C file, gEfiAdapterInfoUndiIPv6SupportGuid is assigned to an incorrect Guid.

Correct the gEfiAdapterInfoUndiIPv6SupportGuid assignment to **EFI_ADAPTER_INFO_UNDI_IPV6_SUPPORT_GUID** to fix this bug.

refer Bug#240: https://github.com/tianocore/edk2-test/issues/240