### PR TITLE
uefi-sct/SctPkg: Coverity Uninitialized Variables Fixes

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/ProtocolHandlerServices/BlackBoxTest/ProtocolHandlerBBTestFunction_2.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/ProtocolHandlerServices/BlackBoxTest/ProtocolHandlerBBTestFunction_2.c
@@ -7606,11 +7606,13 @@ BBTestRegisterProtocolNotifyInterfaceTestCheckPoint4 (
   EFI_STATUS            StatusForGuid107;
   EFI_STATUS            StatusForGuid109;
   EFI_TEST_ASSERTION    AssertionTypeForGuid107;
-  EFI_TEST_ASSERTION    AssertionTypeArrayForGuid108[2];
+  EFI_TEST_ASSERTION    AssertionTypeArrayForGuid108[2] = {EFI_TEST_ASSERTION_PASSED, \
+                                                           EFI_TEST_ASSERTION_PASSED};
   EFI_TEST_ASSERTION    AssertionTypeForGuid109;
-  EFI_TEST_ASSERTION    AssertionTypeArrayForGuid110[2];
-  UINTN                 FirstNotifiedTimesArray[2];
-  UINTN                 SecondNotifiedTimesArray[2];
+  EFI_TEST_ASSERTION    AssertionTypeArrayForGuid110[2] = {EFI_TEST_ASSERTION_PASSED, \ 
+                                                           EFI_TEST_ASSERTION_PASSED};
+  UINTN                 FirstNotifiedTimesArray[2] = {0};
+  UINTN                 SecondNotifiedTimesArray[2] = {0};
 
   UINTN                 Numbers;
 
@@ -8145,8 +8147,8 @@ BBTestRegisterProtocolNotifyInterfaceTestCheckPoint6 (
   EFI_STATUS            Status1, Status2;
   UINTN                 EventIndex;
   NOTIFY_CONTEXT_2      NotifyContextArray[2];
-  NOTIFY_CONTEXT_2      FirstNotifyContextArray[2];
-  NOTIFY_CONTEXT_2      SecondNotifyContextArray[2];  
+  NOTIFY_CONTEXT_2      FirstNotifyContextArray[2] = {{EFI_SUCCESS, 0}};
+  NOTIFY_CONTEXT_2      SecondNotifyContextArray[2] = {{EFI_SUCCESS, 0}};
   EFI_TEST_ASSERTION    AssertionType;
   EFI_TEST_ASSERTION    AssertionTypeGuid292 = EFI_TEST_ASSERTION_FAILED;
   EFI_TEST_ASSERTION    AssertionTypeArrayForGuid293[2] = {EFI_TEST_ASSERTION_FAILED, \
@@ -8181,6 +8183,11 @@ BBTestRegisterProtocolNotifyInterfaceTestCheckPoint6 (
   gtBS->SetMem (NotifyContextArray, 2 * sizeof (NOTIFY_CONTEXT_2), 0);
   NotifyContextArray[0].Status = 0x5a;
   NotifyContextArray[1].Status = 0x5a;
+
+  FirstNotifyContextArray[0].Status = EFI_SUCCESS;
+  FirstNotifyContextArray[1].Status = EFI_SUCCESS;
+  FirstNotifyContextArray[0].NoHandles = 0;
+  FirstNotifyContextArray[1].NoHandles = 0;
 
   Status1 = gtBS->CreateEvent (
                     EVT_NOTIFY_SIGNAL,
@@ -8473,11 +8480,13 @@ BBTestRegisterProtocolNotifyInterfaceTestCheckPoint7 (
   EFI_STATUS            StatusForGuid124;
   EFI_TEST_ASSERTION    AssertionType;
   EFI_TEST_ASSERTION    AssertionTypeForGuid122;
-  EFI_TEST_ASSERTION    AssertionTypeArrayForGuid123[2];
+  EFI_TEST_ASSERTION    AssertionTypeArrayForGuid123[2] = {EFI_TEST_ASSERTION_PASSED, \
+                                                           EFI_TEST_ASSERTION_PASSED};
   EFI_TEST_ASSERTION    AssertionTypeForGuid124;
-  EFI_TEST_ASSERTION    AssertionTypeArrayForGuid125[2];
-  NOTIFY_CONTEXT_2      FirstNotifyContextArray[2];
-  NOTIFY_CONTEXT_2      SecondNotifyContextArray[2];
+  EFI_TEST_ASSERTION    AssertionTypeArrayForGuid125[2] = {EFI_TEST_ASSERTION_PASSED, \
+                                                           EFI_TEST_ASSERTION_PASSED};
+  NOTIFY_CONTEXT_2      FirstNotifyContextArray[2] = {{EFI_SUCCESS, 0}};
+  NOTIFY_CONTEXT_2      SecondNotifyContextArray[2] = {{EFI_SUCCESS, 0}};
 
   UINTN                 Numbers;
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigRouting/BlackBoxTest/HIIConfigRoutingBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigRouting/BlackBoxTest/HIIConfigRoutingBBTestConformance.c
@@ -1168,7 +1168,7 @@ BBTestConfigToBlockConformanceTestCheckpoint3(
 {
   EFI_STATUS            Status;
   EFI_STRING            ConfigResp;
-  UINT8                 Block[TESTBLOCKZISE];
+  UINT8                 Block[TESTBLOCKZISE] = {0};
   UINTN                 BlockSize;
   EFI_STRING            Progress;
   EFI_TEST_ASSERTION    AssertionType;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemBBTestConformance.c
@@ -45,7 +45,7 @@ STATIC
 EFI_STATUS
 UpdateInfoFileName (EFI_FILE_INFO **InfoBuffer, CHAR16* ChangeFileName)
 {
-  EFI_STATUS    Status;
+  EFI_STATUS    Status = EFI_SUCCESS;
   UINTN         Size;
   EFI_FILE_INFO *FileInfo;
 
@@ -695,7 +695,7 @@ BBTestOpenConformanceTestCheckpoint2 (
   EFI_STATUS                Status;
   EFI_FILE                  *Root;
   EFI_TEST_ASSERTION        AssertionType;
-  UINT32                    RandomValue;
+  UINT32                    RandomValue = 0;
   CHAR16                    RandomChars[100];
   CHAR16                    BaseDirName[100];
   CHAR16                    NewDirName[100];

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c
@@ -560,7 +560,7 @@ BBTestOpenExConformanceTestCheckpoint2 (
   EFI_STATUS                StatusAsync;
   EFI_FILE                  *Root;
   EFI_TEST_ASSERTION        AssertionType;
-  UINT32                    RandomValue;
+  UINT32                    RandomValue = 0;
   CHAR16                    RandomChars[100];
   CHAR16                    BaseDirName[100];
   CHAR16                    NewDirName[100];

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextInputEx/BlackBoxTest/SimpleTextInputExBBTestConformance.c
@@ -464,7 +464,7 @@ BBTestSetStateConformanceTestCheckpoint1 (
   IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL          *SimpleTextInputEx
   )
 {
-  EFI_STATUS            Status;
+  EFI_STATUS            Status = EFI_SUCCESS;
   EFI_TEST_ASSERTION    AssertionType;
   EFI_TPL               OldTpl;
 
@@ -520,7 +520,7 @@ BBTestSetStateConformanceTestCheckpoint2 (
   IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL          *SimpleTextInputEx
   )
 {
-  EFI_STATUS            Status;
+  EFI_STATUS            Status = EFI_SUCCESS;
   EFI_TEST_ASSERTION    AssertionType;
   UINTN                 Index;
   EFI_TPL               OldTpl;
@@ -596,7 +596,7 @@ BBTestRegisterKeyNotifyConformanceTestCheckpoint1 (
   IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL          *SimpleTextInputEx
   )
 {
-  EFI_STATUS            Status;
+  EFI_STATUS            Status = EFI_SUCCESS;
   EFI_TEST_ASSERTION    AssertionType;
   VOID                  *NotifyHandle;
   EFI_TPL               OldTpl;
@@ -718,7 +718,7 @@ BBTestRegisterKeyNotifyConformanceTestCheckpoint3 (
   IN EFI_SIMPLE_TEXT_INPUT_EX_PROTOCOL          *SimpleTextInputEx
   )
 {
-  EFI_STATUS            Status;
+  EFI_STATUS            Status = EFI_SUCCESS;
   EFI_TEST_ASSERTION    AssertionType;
   EFI_KEY_DATA          Key;
   EFI_TPL               OldTpl;

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/TestProfile/TestProfile.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/TestProfile/TestProfile.c
@@ -1197,7 +1197,7 @@ Returns:
   EFI_FILE_HANDLE         Handle;
   UINTN                   BufferSize;
   UINTN                   BufferUnicodeSize;
-  CHAR8                   Buffer[MAX_LINE_LEN * 10];
+  CHAR8                   Buffer[MAX_LINE_LEN * 10] = {'\0'};
   CHAR16                  BufferUnicode[MAX_LINE_LEN * 10 * sizeof(CHAR16)];
   CHAR8                   Line[MAX_LINE_LEN * 2];
 

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/IP4NetworkMonitor/IP4NetworkMonitor.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/IP4NetworkMonitor/IP4NetworkMonitor.c
@@ -736,7 +736,7 @@ Returns:
     return Status;
   }
 
-  FragFlag.LLFlag ^= FragFlag.LLFlag;
+  FragFlag.LLFlag = 0;
 
   //
   // Build Fragment Flag
@@ -1218,7 +1218,7 @@ Returns:
   EFI_STATUS        Status;
   EAS_IP4_FRAG_FLAG FragFlag;
 
-  FragFlag.LLFlag ^= FragFlag.LLFlag;
+  FragFlag.LLFlag = 0;
   FragFlag.Flag.SeqId   = HTONL (SeqId);
   FragFlag.Flag.OpCode  = LINK_OPERATION_DATA_ACK;
 

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/ManagedNetworkMonitor/ManagedNetworkMonitor.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/ManagedNetworkMonitor/ManagedNetworkMonitor.c
@@ -850,7 +850,7 @@ Returns:
   }
 
   IsOver = FALSE;
-  FragFlag.LLFlag ^= FragFlag.LLFlag;
+  FragFlag.LLFlag = 0;
   FragFlag.Flag.SeqId   = HTONL (Sequence);
   FragFlag.Flag.OpCode  = LINK_OPERATION_DATA;
   BufferSize            = Size;
@@ -879,7 +879,7 @@ Returns:
     //
     // Build App Flag
     //
-    AppFlag.LLFlag ^= AppFlag.LLFlag;
+    AppFlag.LLFlag = 0;
     AppSequence = AppSequenceSavedForResend;
     AppFlag.Flag.SeqId = HTONL(AppSequence);
     //
@@ -1174,7 +1174,7 @@ Returns:
   }
 
   IsOver = FALSE;
-  FragFlag.LLFlag ^= FragFlag.LLFlag;
+  FragFlag.LLFlag = 0;
 
   RxData = RxToken.Packet.RxData;
   if (RxData->DataLength < sizeof (EAS_MNP_FRAG_FLAG)) {
@@ -1519,7 +1519,7 @@ Returns:
     return EFI_OUT_OF_RESOURCES;
   }
 
-  FragFlag.LLFlag       ^= FragFlag.LLFlag;
+  FragFlag.LLFlag       = 0;
   FragFlag.Flag.SeqId   = HTONL (SeqId);
   FragFlag.Flag.OpCode  = Type;
 


### PR DESCRIPTION
#233 @edhay @stuyod01 

-First patch at addressing the Coverity issues marked as "high impact" 
-Implemented fixes for all issues in the "uninitialized variable" category

Signed-off-by: Sam Kaynor <sam.kaynor@arm.com>

Reviewed-by: Stuart Yoder <stuart.yoder@arm.com>
Reviewed-by: G Edhaya Chandran <edhaya.chandran@arm.com>