### PR TITLE
Edk2-Test: Fix:AdapterInfoBBTest

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestConformance.c
@@ -22,7 +22,7 @@ Abstract:
 
 --*/
 #include "AdapterInfoBBTestMain.h"
-
+#include "SctLib.h"
 
 EFI_STATUS
 EFIAPI

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestFunction.c
@@ -22,7 +22,7 @@ Abstract:
 
 --*/
 #include "AdapterInfoBBTestMain.h"
-
+#include "SctLib.h"
 
 
 

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestMain.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestMain.c
@@ -25,7 +25,7 @@ Abstract:
 --*/
 
 #include "AdapterInfoBBTestMain.h"
-
+#include "SctLib.h"
 
 //
 // Global variables

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestMain.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestMain.h
@@ -161,11 +161,4 @@ BBTestGetSupportedTypesFunctionTest (
   );
 
 
-VOID
-SctInitializeLib (
-  IN EFI_HANDLE                 ImageHandle,
-  IN EFI_SYSTEM_TABLE           *SystemTable
-  );
-
-
 #endif


### PR DESCRIPTION
Fixes: df9a877
AdapterInfoBBTest halts with a synchronous exception. Including "SctLib.h" fixes the issue.

Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Cc: Carolyn Gjertsen <Carolyn.Gjertsen@amd.com>
Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Cc: Eric Jin <eric.jin@intel.com>
Cc: Arvin Chen <arvinx.chen@intel.com>
Cc: Supreeth Venkatesh <Supreeth.Venkatesh@amd.com>