### PR TITLE
TestCase: Add missing EFIAPI specifier in test entry points to fix FTBFS w/ GCC 14

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTest.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTest.h
@@ -184,6 +184,7 @@ BBTestSubmitCommandConformanceTestCheckpoint1 (
   );
 
 EFI_STATUS
+EFIAPI
 BBTestGetCapabilityConformanceTest (
   IN EFI_BB_TEST_PROTOCOL       *This,
   IN VOID                       *ClientInterface,
@@ -192,6 +193,7 @@ BBTestGetCapabilityConformanceTest (
   );
 
 EFI_STATUS
+EFIAPI
 BBTestGetActivePcrBanksConformanceTest (
   IN EFI_BB_TEST_PROTOCOL       *This,
   IN VOID                       *ClientInterface,
@@ -200,6 +202,7 @@ BBTestGetActivePcrBanksConformanceTest (
   );
 
 EFI_STATUS
+EFIAPI
 BBTestHashLogExtendEventConformanceTest (
   IN EFI_BB_TEST_PROTOCOL       *This,
   IN VOID                       *ClientInterface,
@@ -208,6 +211,7 @@ BBTestHashLogExtendEventConformanceTest (
   );
 
 EFI_STATUS
+EFIAPI
 BBTestSubmitCommandConformanceTest (
   IN EFI_BB_TEST_PROTOCOL       *This,
   IN VOID                       *ClientInterface,

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/TCG2/BlackBoxTest/TCG2ProtocolBBTestConformance.c
@@ -39,6 +39,7 @@ Abstract:
  */
 
 EFI_STATUS
+EFIAPI
 BBTestGetCapabilityConformanceTest (
   IN EFI_BB_TEST_PROTOCOL       *This,
   IN VOID                       *ClientInterface,
@@ -98,6 +99,7 @@ BBTestGetCapabilityConformanceTest (
  */
 
 EFI_STATUS
+EFIAPI
 BBTestGetActivePcrBanksConformanceTest (
   IN EFI_BB_TEST_PROTOCOL       *This,
   IN VOID                       *ClientInterface,
@@ -151,6 +153,7 @@ BBTestGetActivePcrBanksConformanceTest (
  */
 
 EFI_STATUS
+EFIAPI
 BBTestHashLogExtendEventConformanceTest (
   IN EFI_BB_TEST_PROTOCOL       *This,
   IN VOID                       *ClientInterface,
@@ -208,6 +211,7 @@ BBTestHashLogExtendEventConformanceTest (
  */
 
 EFI_STATUS
+EFIAPI
 BBTestSubmitCommandConformanceTest (
   IN EFI_BB_TEST_PROTOCOL       *This,
   IN VOID                       *ClientInterface,

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/TCGMemoryOverwriteRequest/BlackBoxTest/TCGMemoryOverwriteRequestBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/TCGMemoryOverwriteRequest/BlackBoxTest/TCGMemoryOverwriteRequestBBTestFunction.c
@@ -56,6 +56,7 @@ Abstract:
  *  @return Other value     Something failed.
  */
 EFI_STATUS
+EFIAPI
 BBTestTCGMemoryOverwriteRequestFunctionTest (
   IN EFI_BB_TEST_PROTOCOL              *This,
   IN VOID                              *ClientInterface,

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/TCGMemoryOverwriteRequest/BlackBoxTest/TCGMemoryOverwriteRequestBBTestMain.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/TCGMemoryOverwriteRequest/BlackBoxTest/TCGMemoryOverwriteRequestBBTestMain.h
@@ -78,6 +78,7 @@ UnloadTCGMemoryOverwriteRequestTest (
   );
 
 EFI_STATUS
+EFIAPI
 BBTestTCGMemoryOverwriteRequestFunctionTest (
   IN EFI_BB_TEST_PROTOCOL             *This,
   IN VOID                             *ClientInterface,


### PR DESCRIPTION
The `SctPkg` does not build with GCC 14, with the following error:

```
/buildroot/cyan/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/TCGMemoryOverwriteRequest/BlackBoxTest/TCGMemoryOverwriteRequestBBTestMain.c:54:5: error: initialization of ‘EFI_STATUS (__attribute__((ms_abi)) *)(EFI_BB_TEST_PROTOCOL *, void *, EFI_TEST_LEVEL,  void *)’ {aka ‘long long unsigned int (__attribute__((ms_abi)) *)(struct _EFI_BB_TEST_PROTOCOL *, void *, unsigned int,  void *)’} from incompatible pointer type ‘EFI_STATUS (*)(EFI_BB_TEST_PROTOCOL *, void *, EFI_TEST_LEVEL,  void *)’ {aka ‘long long unsigned int (*)(struct _EFI_BB_TEST_PROTOCOL *, void *, unsigned int,  void *)’} [-Wincompatible-pointer-types]
   54 |     BBTestTCGMemoryOverwriteRequestFunctionTest
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/buildroot/cyan/edk2-test/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/TCGMemoryOverwriteRequest/BlackBoxTest/TCGMemoryOverwriteRequestBBTestMain.c:54:5: note: (near initialization for ‘gLoadTCGMemoryOverwriteRequestEntryField[0].EntryPoint’)
make: *** [GNUmakefile:331: /buildroot/cyan/edk2-test/uefi-sct/Build/UefiSct/RELEASE_GCC5/X64/SctPkg/TestCase/UEFI/EFI/RuntimeServices/TCGMemoryOverwriteRequest/BlackBoxTest/TCGMemoryOverwriteRequestBBTest/OUTPUT/TCGMemoryOverwriteRequestBBTestMain.obj] Error 1
```

This is due to GCC 14 treating incompatible pointer type occurrences as errors by default. `EFI_BB_TEST_ENTRY_FIELD` uses `EFI_BB_ENTRY_POINT`, which uses `EFIAPI` in the declaration. The entry points defined are not using `EFIAPI`, which in turn causes incompatible pointer types.

Adding EFIAPI to these defined entry point signatures fixes the problem.