### PR TITLE
.github: Compare collaborator GitHub ID's in single case

### DIFF
--- a/.github/scripts/GitHub.py
+++ b/.github/scripts/GitHub.py
@@ -228,8 +228,8 @@ def add_reviewers_to_pr(
     )
 
     # A user can only be added if they are a collaborator of the repository.
-    repo_collaborators = [c.login.strip() for c in repo_gh.get_collaborators() if c]
-    non_collaborators = [u for u in user_names if u not in repo_collaborators]
+    repo_collaborators = [c.login.strip().lower() for c in repo_gh.get_collaborators() if c]
+    non_collaborators = [u for u in user_names if u.lower() not in repo_collaborators]
 
     excluded_pr_reviewers = [pr_author] + current_pr_reviewers + non_collaborators
     new_pr_reviewers = [u for u in user_names if u not in excluded_pr_reviewers]


### PR DESCRIPTION
Since case of a GitHub user name may by specified differently in the `Maintainers.txt` file versus what is actually returned by the GitHub API (actual case), convert both to lowercase for comparison.

Other GitHub user name inputs are directly from APIs and maintain consistent casing.

From edk2 commit:
https://github.com/tianocore/edk2/commit/607c58ef010c9952263f5e5e2553ece4dd2067bc

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com