### PR TITLE
uefi-sct/TimeServices: Updating the TimeFieldsValid() function

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/TimeServices/BlackBoxTest/TimeServicesBBTestMain.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/RuntimeServices/TimeServices/BlackBoxTest/TimeServicesBBTestMain.c
@@ -216,7 +216,7 @@ TimeFieldsValid (
   IN EFI_TIME *Time
   )
 {
-  if (Time->Year < 1998 || Time->Year > 2099) {
+  if (Time->Year < 1900 || Time->Year > 9999) {
     return FALSE;
   }
 


### PR DESCRIPTION
Updating the TimeFieldsValid() function to validate the Year field against the full range specified in the UEFI spec (1900–9999) to ensure compliance

Fixes #263 

This patch resolves the issue by correcting the logic in TimeFieldsValid()