### PR TITLE
SctPkg/EasDispatcher: Remove unused variables in EftpImplement

### DIFF
--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasDispatcher/Exec/EftpImplement.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasDispatcher/Exec/EftpImplement.c
@@ -39,9 +39,6 @@ STATIC UINTN                        mRealFileSize         = 0;
 STATIC VOID                         *mRealFileBuffer      = NULL;
 STATIC UINT64                       mTransferSize         = 0;
 
-STATIC EFI_MANAGED_NETWORK_PROTOCOL *TmpMnp               = NULL;
-STATIC EFI_SERVICE_BINDING_PROTOCOL *TmpMnpSb             = NULL;
-STATIC EFI_HANDLE                   TmpMnpInstanceHandle  = NULL;
 STATIC EFI_EFTP_PROTOCOL            *EftpIo               = NULL;
 STATIC EFI_SERVICE_BINDING_PROTOCOL *TmpEftpSb            = NULL;
 STATIC EFI_HANDLE                   TmpEftpInstanceHandle = NULL;


### PR DESCRIPTION
Remove unused variables causing build failures if -Werror is enabled.

Build error:

/local/mnt/workspace/sandbox/uefi/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasDispatcher/Exec/EftpImplement.c:42:38: error: unused variable 'TmpMnp' [-Werror,-Wunused-variable]
   42 | STATIC EFI_MANAGED_NETWORK_PROTOCOL *TmpMnp               = NULL;
      |                                      ^~~~~~
/local/mnt/workspace/sandbox/uefi/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasDispatcher/Exec/EftpImplement.c:43:38: error: unused variable 'TmpMnpSb' [-Werror,-Wunused-variable]
   43 | STATIC EFI_SERVICE_BINDING_PROTOCOL *TmpMnpSb             = NULL;
      |                                      ^~~~~~~~
/local/mnt/workspace/sandbox/uefi/SctPkg/TestInfrastructure/SCT/Framework/ENTS/EasDispatcher/Exec/EftpImplement.c:44:37: error: unused variable 'TmpMnpInstanceHandle' [-Werror,-Wunused-variable]
   44 | STATIC EFI_HANDLE                   TmpMnpInstanceHandle  = NULL;
      |                                     ^~~~~~~~~~~~~~~~~~~~
3 errors generated.

