### PR TITLE
[RFC] uefi-sct/SctPkg: include CompilerIntrinsicsLib in Pkcs7BBTest.inf

### DIFF
--- a/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
@@ -138,6 +138,9 @@
 
 !include MdePkg/MdeLibs.dsc.inc
 
+[LibraryClasses.RISCV64]
+  NULL|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
+
 [LibraryClasses.common]
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf


### PR DESCRIPTION
Avoid a build error on riscv64

    .../PKCS7Verify/BlackBoxTest/Pkcs7BBTestMain.c:146:
    (.text.InitializePkcs7VerifyBBTest+0xe8):
    undefined reference to `memcpy'

---

This is enough to support building on riscv64 with edk2-stable202505.
But wouldn't it be preferable to patch change edk2/MdePkg/MdeLibs.dsc.inc to add
```
[LibraryClasses]
NULL|MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
```
for all architectures.