### PR TITLE
SctPkg: Remove duplicate gTestGenericFailureGuid definition in ValidHiiImage

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/ImageServices/BlackBoxTest/Dependency/ValidHiiImage1/ValidHiiImage1.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/BootServices/ImageServices/BlackBoxTest/Dependency/ValidHiiImage1/ValidHiiImage1.inf
@@ -50,8 +50,5 @@
   SctLib
   EfiTestLib
 
-[Guids]
-  gTestGenericFailureGuid
-
 [Protocols]
   gEfiTestProfileLibraryGuid


### PR DESCRIPTION
REF: https://github.com/tianocore/edk2-test/issues/271

Remove the [Guids] entry for gTestGenericFailureGuid in ValidHiiImage1.inf, as this GUID is already defined and implemented in EfiTestLib. Leaving this entry causes multiple definition errors when linking with GCC.

Cc: G Edhaya Chandran <edhaya.chandran@arm.com>
Cc: Sunny Wang <sunny.wang@arm.com>
Cc: Simon Yang <simon1.yang@intel.com>