### PR TITLE
uefi-sct/SctPkg: Fix x64 GCC build by enforcing Microsoft x64 ABI

### DIFF
--- a/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
+++ b/uefi-sct/SctPkg/UEFI/UEFI_SCT.dsc
@@ -74,13 +74,13 @@
   MSFT:*_*_X64_PP_FLAGS    = /D EFIX64
 
 #  GCC:*_*_IA32_CC_FLAGS     = -D EFI32 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m32 -mabi=ms -D MDE_CPU_X32
-  GCC:*_*_IA32_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
+  GCC:*_*_IA32_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error -mabi=ms
 #  GCC:*_*_IA32_VFRPP_FLAGS  = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_APP_FLAGS    = -D EFI32 $(GCC_VER_MACRO)
 #  GCC:*_*_IA32_PP_FLAGS     = -D EFI32 $(GCC_VER_MACRO)
 
 #  GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -ffreestanding -nostdinc -nostdlib -Wno-error -mno-red-zone -Wno-address -mno-stack-arg-probe "-DEFIAPI=__attribute__((ms_abi))" -m64 -mcmodel=large -mabi=ms -D MDE_CPU_X64
-   GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error 
+   GCC:*_*_X64_CC_FLAGS     = -D EFIX64 $(GCC_VER_MACRO) -Wno-error -mabi=ms
 #  GCC:*_*_X64_VFRPP_FLAGS  = -D EFIX64 $(GCC_VER_MACRO)
 #  GCC:*_*_X64_APP_FLAGS    = -D EFIX64 $(GCC_VER_MACRO)
 #  GCC:*_*_X64_PP_FLAGS     = -D EFIX64 $(GCC_VER_MACRO)


### PR DESCRIPTION
REF: https://github.com/tianocore/edk2-test/issues/236

UEFI Specification states that on x64 platforms, all UEFI interfaces must follow the Microsoft x64 calling convention. GCC by default uses the System V AMD64 ABI, which results in mismatched calling conventions when invoking UEFI services, causing SCT binaries built on Linux to hang.

Add `-mabi=ms` to GCC x64 build flags to ensure GCC generates code compatible with the Microsoft x64 ABI. This aligns GCC-compiled binaries with MSVC-compiled binaries and resolves the hang observed when running SCT built on Linux.

UEFI Spec Reference: Section 2.3.4.2 Detailed Calling Conventions

Cc: G Edhaya Chandran <edhaya.chandran@arm.com>
Cc: Sunny Wang <sunny.wang@arm.com>
Cc: Ann Cheng <ann.cheng@arm.com>