### PR TITLE
uefi-sct/SctPkg: Coverity corruptions fixes

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestMain.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DevicePathToText/BlackBoxTest/DevicePathToTextBBTestMain.c
@@ -1062,7 +1062,7 @@ BuildAcpiExpDeviceNode (
   	goto InValidText;
   }
 
-  CIDStr    = L"0";
+  CIDStr    = L'\0';
   UIDSTRStr = L"\0";
 
   for (OptionalParamIndex = 0; OptionalParamIndex < 2; OptionalParamIndex++) {

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextIn/BlackBoxTest/SimpleTextInBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextIn/BlackBoxTest/SimpleTextInBBTestConformance.c
@@ -55,7 +55,7 @@ BBTestReadKeyStrokeConformanceManualTest (
   UINTN                                Index;
   EFI_TEST_ASSERTION                   AssertionType;
   EFI_INPUT_KEY                        Key;
-  CHAR16                               KeyBuffer[MAX_KEY_BUFFER_SIZE];
+  CHAR16                               KeyBuffer[MAX_KEY_BUFFER_SIZE + 1];
 
   EFI_DEVICE_PATH_PROTOCOL             *DevicePath;
   CHAR16                               *DevicePathStr;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextIn/BlackBoxTest/SimpleTextInBBTestStress.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleTextIn/BlackBoxTest/SimpleTextInBBTestStress.c
@@ -53,7 +53,7 @@ BBTestReadKeyStrokeManualTest (
 
   EFI_TEST_ASSERTION                   AssertionType;
   EFI_INPUT_KEY                        Key;
-  CHAR16                               KeyBuffer[MAX_KEY_BUFFER_SIZE];
+  CHAR16                               KeyBuffer[MAX_KEY_BUFFER_SIZE + 1];
 
   EFI_DEVICE_PATH_PROTOCOL             *DevicePath;
   CHAR16                               *DevicePathStr;

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/TestProfile/TestProfile.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Drivers/TestProfile/TestProfile.c
@@ -1508,6 +1508,10 @@ Returns:
     return EFI_INVALID_PARAMETER;
   }
 
+  if (*maxLength == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
   Private = EFI_INI_FILE_PRIVATE_DATA_FROM_THIS (This);
 
   //
@@ -1851,6 +1855,10 @@ Returns:
   _alltrim (tmpEntry);
 
   if (SctAsciiStrLen (tmpSection) == 0 || SctAsciiStrLen (tmpEntry) == 0) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (*maxLength == 0) {
     return EFI_INVALID_PARAMETER;
   }
 

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/ManagedNetworkMonitor/ManagedNetworkMonitor.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/ENTS/MonitorServices/ManagedNetworkMonitor/ManagedNetworkMonitor.c
@@ -124,7 +124,7 @@ EFI_MANAGED_NETWORK_RECEIVE_DATA            mMnpRxDataTemplate = {
   NULL                    // PacketData
 };
 
-CHAR8                                       MnpBufferIn[MNP_BUFFER_IN_MAX];
+CHAR8                                       MnpBufferIn[MNP_BUFFER_IN_MAX + 1];
 CHAR8                                       *MnpBufferOut;
 UINTN                                       MnpBufferOutSize;
 


### PR DESCRIPTION
Fixed high impact corruption errors found using Coverity static code analysis