### PR TITLE
uefi-sct/SctPkg: Fixed build issue due to no UGAIO.

### DIFF
--- a/uefi-sct/SctPkg/Config/Data/Category.ini
+++ b/uefi-sct/SctPkg/Config/Data/Category.ini
@@ -307,13 +307,6 @@ Description   =
 
 [Category Data]
 Revision      = 0x00010000
-CategoryGuid  = 61A4D49E-6F68-4F1B-B922-A86EED0B07A2
-InterfaceGuid = 61A4D49E-6F68-4F1B-B922-A86EED0B07A2
-Name          = ConsoleSupportTest\UGAIOProtocolTest
-Description   =
-
-[Category Data]
-Revision      = 0x00010000
 CategoryGuid  = 31878C87-0B75-11D5-9A4F-0090273FC14D
 InterfaceGuid = 31878C87-0B75-11D5-9A4F-0090273FC14D
 Name          = ConsoleSupportTest\SimplePointerProtocolTest

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestPlatform_uefi.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestPlatform_uefi.c
@@ -34,7 +34,6 @@ Abstract:
 #include EFI_PROTOCOL_DEFINITION (SimpleTextInEx)
 #include EFI_PROTOCOL_DEFINITION (SimpleTextOut)
 #include EFI_PROTOCOL_DEFINITION (UgaDraw)
-#include EFI_PROTOCOL_DEFINITION (UgaIo)
 #include EFI_PROTOCOL_DEFINITION (SimplePointer)
 #include EFI_PROTOCOL_DEFINITION (BlockIo)
 #include EFI_PROTOCOL_DEFINITION (DiskIo)


### PR DESCRIPTION
REF: https://github.com/tianocore/edk2-test/issues/280

edk2 master removes all supported code for UGAIO, this causes build failures due to absence of ugaio.h.
This patch removes the dependency on UGAIO and fixes the build issue.

Cc: G Edhaya Chandran <edhaya.chandran@arm.com>
Cc: Sunny Wang <sunny.wang@arm.com>
Cc: Ann Cheng <ann.cheng@arm.com>
Cc: Richard Lyu <richard.lyu@suse.com>