### PR TITLE
SctPkg: Update LoongArch exception defines

### DIFF
--- a/uefi-sct/SctPkg/UEFI/Protocol/DebugSupport.h
+++ b/uefi-sct/SctPkg/UEFI/Protocol/DebugSupport.h
@@ -662,9 +662,23 @@ typedef struct {
   UINT64  X31;
 } EFI_SYSTEM_CONTEXT_RISCV64;
 
-//
-// LoongArch processor exception types.
-//
+///
+/// LoongArch processor exception types.
+///
+/// The exception types is located in the CSR ESTAT
+/// register offset 16 bits, width 6 bits.
+///
+/// If you want to register an exception hook, you can
+/// shfit the number left by 16 bits, and the exception
+/// handler will know the types.
+///
+/// For example:
+/// mCpu->CpuRegisterInterruptHandler (
+///         mCpu,
+///         (EXCEPT_LOONGARCH_PPI << CSR_ESTAT_EXC_SHIFT),
+///         PpiExceptionHandler
+///         );
+///
 #define EXCEPT_LOONGARCH_INT   0
 #define EXCEPT_LOONGARCH_PIL   1
 #define EXCEPT_LOONGARCH_PIS   2
@@ -684,11 +698,22 @@ typedef struct {
 #define EXCEPT_LOONGARCH_SXD   16
 #define EXCEPT_LOONGARCH_ASXD  17
 #define EXCEPT_LOONGARCH_FPE   18
-#define EXCEPT_LOONGARCH_TBR   64 // For code only, there is no such type in the ISA spec, the TLB refill is defined for an independent exception.
+#define EXCEPT_LOONGARCH_WPE   19
+#define EXCEPT_LOONGARCH_BTD   20
+#define EXCEPT_LOONGARCH_BTE   21
+#define EXCEPT_LOONGARCH_GSPR  22
+#define EXCEPT_LOONGARCH_HVC   23
+#define EXCEPT_LOONGARCH_GCXC  24
 
-//
-// LoongArch processor Interrupt types.
-//
+///
+/// For coding convenience, define the maximum valid
+/// LoongArch exception.
+///
+#define MAX_LOONGARCH_EXCEPTION  64
+
+///
+/// LoongArch processor Interrupt types.
+///
 #define EXCEPT_LOONGARCH_INT_SIP0   0
 #define EXCEPT_LOONGARCH_INT_SIP1   1
 #define EXCEPT_LOONGARCH_INT_IP0    2
@@ -703,11 +728,11 @@ typedef struct {
 #define EXCEPT_LOONGARCH_INT_TIMER  11
 #define EXCEPT_LOONGARCH_INT_IPI    12
 
-//
-// For coding convenience, define the maximum valid
-// LoongArch interrupt.
-//
-#define MAX_LOONGARCH_INTERRUPT  14
+///
+/// For coding convenience, define the maximum valid
+/// LoongArch interrupt.
+///
+#define MAX_LOONGARCH_INTERRUPT  16
 
 typedef struct {
   UINT64    R0;


### PR DESCRIPTION
This patch sync the UEFI v2.11 LoongArch specific parts and updates the LoongArch exception descriptions in the header file.

Signed-off- by: Chao Li <lichao@loongson.cn>