### PR TITLE
Disable BBTestGetImageInfoConformanceTestCheckpoint4 test

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/FirmwareManagement/BlackBoxTest/FirmwareManagementBBTestConformance.c
@@ -606,7 +606,9 @@ BBTestGetImageInfoConformanceTest (
   BBTestGetImageInfoConformanceTestCheckpoint1 (StandardLib, FirmwareManagement);
   BBTestGetImageInfoConformanceTestCheckpoint2 (StandardLib, FirmwareManagement);
   BBTestGetImageInfoConformanceTestCheckpoint3 (StandardLib, FirmwareManagement);
-  BBTestGetImageInfoConformanceTestCheckpoint4 (StandardLib, FirmwareManagement);
+  //This test is temporarily disabled due to clarification pending in the 
+  //UEFI Specification
+  //BBTestGetImageInfoConformanceTestCheckpoint4 (StandardLib, FirmwareManagement);
   BBTestGetImageInfoConformanceTestCheckpoint5 (StandardLib, FirmwareManagement);
   BBTestGetImageInfoConformanceTestCheckpoint6 (StandardLib, FirmwareManagement);
   BBTestGetImageInfoConformanceTestCheckpoint7 (StandardLib, FirmwareManagement);


### PR DESCRIPTION
This test is disabled due to a clarification pending in UEFI Specification.
The test causes synchronous exception in some environments

Please see issue https://github.com/tianocore/edk2-test/issues/297 for more details.