### PR TITLE
Fix ParameterBlockSize usage and GUID comparison in SctPkg/PlatformToDriverConfigurationBBTest

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PlatformToDriverConfiguration/BlackBoxTest/ConfigureClpParameterBlkBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PlatformToDriverConfiguration/BlackBoxTest/ConfigureClpParameterBlkBBTestFunction.c
@@ -164,17 +164,18 @@ BBTestCLPCommandAutoTest (
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL             *StandardLib;
   EFI_STATUS                                     Status;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock = NULL;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguation;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   EFI_HANDLE                                     ChildHandle;
-  UINTN                                          *Instance;
+  VOID                                           *ProtocolInstance = NULL;
+  UINTN                                          Instance = 0;
   EFI_GUID                                       *ParameterTypeGuid = NULL;
   UINTN                                          ParameterBlockSize = 0;
-  CLP_CMD                                        *CLPCmd;
+  CLP_CMD                                        *CLPCmd = NULL;
   UINTN                                          Index, Index1;
 
   //
@@ -197,7 +198,7 @@ BBTestCLPCommandAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguation = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -216,7 +217,7 @@ BBTestCLPCommandAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -229,7 +230,7 @@ BBTestCLPCommandAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // *ParameterTypeGuid =EFI_NULL_GUID;
@@ -248,7 +249,7 @@ BBTestCLPCommandAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
@@ -256,12 +257,14 @@ BBTestCLPCommandAutoTest (
   //
   Status = EFI_SUCCESS;
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
+    Instance = 0;
+    Status   = EFI_SUCCESS;
     while (!EFI_ERROR (Status)) {
       Status = PlatformToDriverConfiguation->Query (
                                                PlatformToDriverConfiguation,
                                                CtrlerHandles[CtrlerHandleIndex],
                                                ChildHandle,
-                                               Instance,
+                                               &Instance,
                                                &ParameterTypeGuid,
                                                (VOID **)&EfiClpParameterBlock,
                                                &ParameterBlockSize
@@ -271,9 +274,9 @@ BBTestCLPCommandAutoTest (
                                                  PlatformToDriverConfiguation,
                                                  CtrlerHandles[CtrlerHandleIndex],
                                                  ChildHandle,
-                                                 Instance,
+                                                 &Instance,
                                                  ParameterTypeGuid,
-                                                 &EfiClpParameterBlock,
+                                                 EfiClpParameterBlock,
                                                  ParameterBlockSize,
                                                  EfiPlatformConfigurationActionNone
                                                  );
@@ -320,7 +323,7 @@ BBTestCLPCommandAutoTest (
                      (UINTN)__LINE__,
                      Status
                      );
-      return Status;
+      goto OnExit;
     }
 
     Status = ParseCLPCommandLine (EfiClpParameterBlock, CLPCmd);
@@ -377,14 +380,26 @@ BBTestCLPCommandAutoTest (
                    (CHAR16 *)CLPCmd->CLPCmdVerb,
                    EFI_SUCCESS
                    );
+    Status = EFI_SUCCESS;
   } else {
-    gtBS->FreePool (EfiClpParameterBlock);
-    return EFI_UNSUPPORTED;
+    Status = EFI_UNSUPPORTED;
+    goto OnExit;
   }
 
-  gtBS->FreePool (CLPCmd);
-  gtBS->FreePool (EfiClpParameterBlock);
-  return EFI_SUCCESS;
+OnExit:
+  if (CtrlerHandles) {
+    SctFreePool (CtrlerHandles);
+  }
+
+  if (CLPCmd) {
+    gtBS->FreePool (CLPCmd);
+  }
+
+  if (EfiClpParameterBlock) {
+    gtBS->FreePool (EfiClpParameterBlock);
+  }
+
+  return Status;
 }
 
 /**
@@ -409,17 +424,18 @@ BBTestCLPReturnStringAutoTest (
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL             *StandardLib;
   EFI_STATUS                                     Status;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock = NULL;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguation;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   EFI_HANDLE                                     ChildHandle;
-  UINTN                                          *Instance;
+  VOID                                           *ProtocolInstance  = NULL;
+  UINTN                                          Instance           = 0;
   EFI_GUID                                       *ParameterTypeGuid = NULL;
   UINTN                                          ParameterBlockSize;
-  CLP_CMD                                        *CLPCmd;
+  CLP_CMD                                        *CLPCmd = NULL;
   UINTN                                          Index;
 
   //
@@ -442,7 +458,7 @@ BBTestCLPReturnStringAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguation = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -461,7 +477,7 @@ BBTestCLPReturnStringAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -474,7 +490,7 @@ BBTestCLPReturnStringAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // *ParameterTypeGuid =EFI_NULL_GUID;
@@ -493,7 +509,7 @@ BBTestCLPReturnStringAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
@@ -501,12 +517,14 @@ BBTestCLPReturnStringAutoTest (
   //
   Status = EFI_SUCCESS;
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
+    Instance = 0;
+    Status   = EFI_SUCCESS;
     while (!EFI_ERROR (Status)) {
       Status = PlatformToDriverConfiguation->Query (
                                                PlatformToDriverConfiguation,
                                                CtrlerHandles[CtrlerHandleIndex],
                                                ChildHandle,
-                                               Instance,
+                                               &Instance,
                                                &ParameterTypeGuid,
                                                (VOID **)&EfiClpParameterBlock,
                                                &ParameterBlockSize
@@ -516,9 +534,9 @@ BBTestCLPReturnStringAutoTest (
                                                  PlatformToDriverConfiguation,
                                                  CtrlerHandles[CtrlerHandleIndex],
                                                  ChildHandle,
-                                                 Instance,
+                                                 &Instance,
                                                  ParameterTypeGuid,
-                                                 &EfiClpParameterBlock,
+                                                 EfiClpParameterBlock,
                                                  ParameterBlockSize,
                                                  EfiPlatformConfigurationActionNone
                                                  );
@@ -548,9 +566,9 @@ BBTestCLPReturnStringAutoTest (
                                            PlatformToDriverConfiguation,
                                            CtrlerHandles[CtrlerHandleIndex],
                                            ChildHandle,
-                                           Instance,
+                                           &Instance,
                                            ParameterTypeGuid,
-                                           &EfiClpParameterBlock,
+                                           EfiClpParameterBlock,
                                            ParameterBlockSize,
                                            EfiPlatformConfigurationActionNone
                                            );
@@ -594,7 +612,7 @@ BBTestCLPReturnStringAutoTest (
                      (UINTN)__LINE__,
                      Status
                      );
-      return Status;
+      goto OnExit;
     }
 
     //
@@ -641,13 +659,27 @@ BBTestCLPReturnStringAutoTest (
                      EFI_SUCCESS
                      );
     }
+
+    Status = EFI_SUCCESS;
   } else {
-    gtBS->FreePool (EfiClpParameterBlock);
-    return EFI_UNSUPPORTED;
+    Status = EFI_UNSUPPORTED;
+    goto OnExit;
   }
 
-  gtBS->FreePool (EfiClpParameterBlock);
-  return EFI_SUCCESS;
+OnExit:
+  if (CtrlerHandles) {
+    SctFreePool (CtrlerHandles);
+  }
+
+  if (CLPCmd) {
+    gtBS->FreePool (CLPCmd);
+  }
+
+  if (EfiClpParameterBlock) {
+    gtBS->FreePool (EfiClpParameterBlock);
+  }
+
+  return Status;
 }
 
 /**
@@ -672,14 +704,15 @@ BBTestCLPCmdStatusAutoTest (
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL             *StandardLib;
   EFI_STATUS                                     Status;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock = NULL;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguation;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   EFI_HANDLE                                     ChildHandle;
-  UINTN                                          *Instance;
+  VOID                                           *ProtocolInstance  = NULL;
+  UINTN                                          Instance           = 0;
   EFI_GUID                                       *ParameterTypeGuid = NULL;
   UINTN                                          ParameterBlockSize;
   CHAR16                                         Status_Tag;
@@ -704,7 +737,7 @@ BBTestCLPCmdStatusAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguation = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -723,7 +756,7 @@ BBTestCLPCmdStatusAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -736,7 +769,7 @@ BBTestCLPCmdStatusAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // *ParameterTypeGuid =EFI_NULL_GUID;
@@ -755,7 +788,7 @@ BBTestCLPCmdStatusAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
@@ -763,12 +796,14 @@ BBTestCLPCmdStatusAutoTest (
   //
   Status = EFI_SUCCESS;
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
+    Instance = 0;
+    Status   = EFI_SUCCESS;
     while (!EFI_ERROR (Status)) {
       Status = PlatformToDriverConfiguation->Query (
                                                PlatformToDriverConfiguation,
                                                CtrlerHandles[CtrlerHandleIndex],
                                                ChildHandle,
-                                               Instance,
+                                               &Instance,
                                                &ParameterTypeGuid,
                                                (VOID **)&EfiClpParameterBlock,
                                                &ParameterBlockSize
@@ -778,9 +813,9 @@ BBTestCLPCmdStatusAutoTest (
                                                  PlatformToDriverConfiguation,
                                                  CtrlerHandles[CtrlerHandleIndex],
                                                  ChildHandle,
-                                                 Instance,
+                                                 &Instance,
                                                  ParameterTypeGuid,
-                                                 &EfiClpParameterBlock,
+                                                 EfiClpParameterBlock,
                                                  ParameterBlockSize,
                                                  EfiPlatformConfigurationActionNone
                                                  );
@@ -851,10 +886,20 @@ BBTestCLPCmdStatusAutoTest (
                    EFI_SUCCESS
                    );
   } else {
-    return EFI_UNSUPPORTED;
+    Status = EFI_UNSUPPORTED;
+    goto OnExit;
   }
 
-  return EFI_SUCCESS;
+OnExit:
+  if (CtrlerHandles) {
+    SctFreePool (CtrlerHandles);
+  }
+
+  if (EfiClpParameterBlock) {
+    gtBS->FreePool (EfiClpParameterBlock);
+  }
+
+  return Status;
 }
 
 /**
@@ -879,14 +924,15 @@ BBTestCLPErrorValueAutoTest (
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL             *StandardLib;
   EFI_STATUS                                     Status;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock = NULL;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguation;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   EFI_HANDLE                                     ChildHandle;
-  UINTN                                          *Instance;
+  VOID                                           *ProtocolInstance  = NULL;
+  UINTN                                          Instance           = 0;
   EFI_GUID                                       *ParameterTypeGuid = NULL;
   UINTN                                          ParameterBlockSize;
   //  UINT8                                          Index;
@@ -912,7 +958,7 @@ BBTestCLPErrorValueAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguation = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -931,7 +977,7 @@ BBTestCLPErrorValueAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -944,7 +990,7 @@ BBTestCLPErrorValueAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // *ParameterTypeGuid =EFI_NULL_GUID;
@@ -963,7 +1009,7 @@ BBTestCLPErrorValueAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
@@ -971,12 +1017,14 @@ BBTestCLPErrorValueAutoTest (
   //
   Status = EFI_SUCCESS;
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
+    Instance = 0;
+    Status   = EFI_SUCCESS;
     while (!EFI_ERROR (Status)) {
       Status = PlatformToDriverConfiguation->Query (
                                                PlatformToDriverConfiguation,
                                                CtrlerHandles[CtrlerHandleIndex],
                                                ChildHandle,
-                                               Instance,
+                                               &Instance,
                                                &ParameterTypeGuid,
                                                (VOID **)&EfiClpParameterBlock,
                                                &ParameterBlockSize
@@ -986,9 +1034,9 @@ BBTestCLPErrorValueAutoTest (
                                                  PlatformToDriverConfiguation,
                                                  CtrlerHandles[CtrlerHandleIndex],
                                                  ChildHandle,
-                                                 Instance,
+                                                 &Instance,
                                                  ParameterTypeGuid,
-                                                 &EfiClpParameterBlock,
+                                                 EfiClpParameterBlock,
                                                  ParameterBlockSize,
                                                  EfiPlatformConfigurationActionNone
                                                  );
@@ -1102,10 +1150,23 @@ BBTestCLPErrorValueAutoTest (
                    EFI_SUCCESS
                    );
 
-    return EFI_SUCCESS;
+    Status = EFI_SUCCESS;
+    goto OnExit;
   }
 
-  return EFI_UNSUPPORTED;
+  Status = EFI_UNSUPPORTED;
+  goto OnExit;
+
+OnExit:
+  if (CtrlerHandles) {
+    SctFreePool (CtrlerHandles);
+  }
+
+  if (EfiClpParameterBlock) {
+    gtBS->FreePool (EfiClpParameterBlock);
+  }
+
+  return Status;
 }
 
 /**
@@ -1130,16 +1191,17 @@ BBTestCLPMessageCodeAutoTest (
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL             *StandardLib;
   EFI_STATUS                                     Status;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK                *EfiClpParameterBlock = NULL;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguation;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   EFI_HANDLE                                     ChildHandle;
-  UINTN                                          *Instance;
+  VOID                                           *ProtocolInstance  = NULL;
+  UINTN                                          Instance           = 0;
   EFI_GUID                                       *ParameterTypeGuid = NULL;
-  UINTN                                          ParameterBlockSize;
+  UINTN                                          ParameterBlockSize = 0;
   UINT16                                         MsgCodeValue;
 
   //
@@ -1162,7 +1224,7 @@ BBTestCLPMessageCodeAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguation = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -1181,7 +1243,7 @@ BBTestCLPMessageCodeAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -1194,7 +1256,7 @@ BBTestCLPMessageCodeAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // *ParameterTypeGuid =EFI_NULL_GUID;
@@ -1213,7 +1275,7 @@ BBTestCLPMessageCodeAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
@@ -1221,12 +1283,14 @@ BBTestCLPMessageCodeAutoTest (
   //
   Status = EFI_SUCCESS;
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
+    Instance = 0;
+    Status   = EFI_SUCCESS;
     while (!EFI_ERROR (Status)) {
       Status = PlatformToDriverConfiguation->Query (
                                                PlatformToDriverConfiguation,
                                                CtrlerHandles[CtrlerHandleIndex],
                                                ChildHandle,
-                                               Instance,
+                                               &Instance,
                                                &ParameterTypeGuid,
                                                (VOID **)&EfiClpParameterBlock,
                                                &ParameterBlockSize
@@ -1236,9 +1300,9 @@ BBTestCLPMessageCodeAutoTest (
                                                  PlatformToDriverConfiguation,
                                                  CtrlerHandles[CtrlerHandleIndex],
                                                  ChildHandle,
-                                                 Instance,
+                                                 &Instance,
                                                  ParameterTypeGuid,
-                                                 &EfiClpParameterBlock,
+                                                 EfiClpParameterBlock,
                                                  ParameterBlockSize,
                                                  EfiPlatformConfigurationActionNone
                                                  );
@@ -1276,7 +1340,8 @@ BBTestCLPMessageCodeAutoTest (
     MsgCodeValue = EfiClpParameterBlock->CLPMsgCode;
     if (MsgCodeValue & 0x8000) {
       // Bit15=1, Message Code is OEM Specific,ignore it
-      return EFI_UNSUPPORTED;
+      Status = EFI_UNSUPPORTED;
+      goto OnExit;
     } else {
       if ((EfiClpParameterBlock->CLPMsgCode <= 130) && (EfiClpParameterBlock->CLPMsgCode >= 0)) {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
@@ -1296,9 +1361,20 @@ BBTestCLPMessageCodeAutoTest (
                    EfiClpParameterBlock->CLPMsgCode,
                    EFI_SUCCESS
                    );
+    Status = EFI_SUCCESS;
   } else {
-    return EFI_UNSUPPORTED;
+    Status = EFI_UNSUPPORTED;
+    goto OnExit;
   }
 
-  return EFI_SUCCESS;
+OnExit:
+  if (CtrlerHandles) {
+    SctFreePool (CtrlerHandles);
+  }
+
+  if (EfiClpParameterBlock) {
+    gtBS->FreePool (EfiClpParameterBlock);
+  }
+
+  return Status;
 }

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PlatformToDriverConfiguration/BlackBoxTest/PlatformToDriverConfigurationBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PlatformToDriverConfiguration/BlackBoxTest/PlatformToDriverConfigurationBBTestConformance.c
@@ -51,14 +51,15 @@ BBTestQueryConformanceAutoTest (
   EFI_STATUS                                     Status;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguration;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   // EFI_HANDLE                                         ChildHandle;
-  UINTN                            *Instance;
-  EFI_GUID                         *ParameterTypeGuid;
-  UINTN                            ParameterClpBlockSize;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK  *ParameterClpBlock;
+  VOID                             *ProtocolInstance     = NULL;
+  UINTN                            Instance              = 0;
+  EFI_GUID                         *ParameterTypeGuid    = NULL;
+  UINTN                            ParameterClpBlockSize = 0;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK  *ParameterClpBlock    = NULL;
 
   //
   // Get the Standard Library Interface
@@ -80,7 +81,7 @@ BBTestQueryConformanceAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguration = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -103,7 +104,8 @@ BBTestQueryConformanceAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+
+    goto OnExit;
   }
 
   //
@@ -112,7 +114,7 @@ BBTestQueryConformanceAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -125,20 +127,20 @@ BBTestQueryConformanceAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // Assertion Point
 
   // check point 1
-  // EFI_INVALID_PARAMETER returned with ContrllerHandle invalid
+  // EFI_INVALID_PARAMETER returned with ControllerHandle invalid
   //
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
     Status = PlatformToDriverConfiguration->Query (
                                               PlatformToDriverConfiguration,
                                               NULL,
                                               NULL,
-                                              Instance,
+                                              &Instance,
                                               &ParameterTypeGuid,
                                               (VOID **)&ParameterClpBlock,
                                               &ParameterClpBlockSize
@@ -171,10 +173,10 @@ BBTestQueryConformanceAutoTest (
                                          PlatformToDriverConfiguration,
                                          CtrlerHandles[CtrlerHandleIndex],
                                          NULL,
-                                         Instance,
+                                         &Instance,
                                          &ParameterTypeGuid,
                                          NULL,
-                                         ParameterClpBlockSize
+                                         &ParameterClpBlockSize
                                          );
   if(Status == EFI_DEVICE_ERROR) {
     AssertionType = EFI_TEST_ASSERTION_PASSED;
@@ -203,7 +205,7 @@ BBTestQueryConformanceAutoTest (
                                          PlatformToDriverConfiguration,
                                          CtrlerHandles[CtrlerHandleIndex],
                                          NULL,
-                                         Instance,
+                                         &Instance,
                                          &ParameterTypeGuid,
                                          &ParameterClpBlock,
                                          NULL
@@ -229,7 +231,7 @@ BBTestQueryConformanceAutoTest (
 
   //
   // Check Point 4
-  // Invoke Query() with invalide Instance=NULL
+  // Invoke Query() with invalid Instance=NULL
   // EFI_INVALID_PARAMETER is expected
   //
 
@@ -261,11 +263,18 @@ BBTestQueryConformanceAutoTest (
                    );
   }
 
+  Status = EFI_SUCCESS;
+
+OnExit:
   if (CtrlerHandles) {
     SctFreePool (CtrlerHandles);
   }
 
-  return EFI_SUCCESS;
+  if (ParameterClpBlock) {
+    gtBS->FreePool (ParameterClpBlock);
+  }
+
+  return Status;
 }
 
 /**
@@ -292,14 +301,15 @@ BBTestResponseConformanceAutoTest (
   EFI_STATUS                                     Status;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguration;
   EFI_TEST_ASSERTION                             AssertionType, RAssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   // EFI_HANDLE                                         ChildHandle;
-  UINTN                              *Instance;
-  EFI_GUID                           *ParameterTypeGuid;
-  UINTN                              ParameterClpBlockSize;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK    *ParameterClpBlock;
+  VOID                               *ProtocolInstance     = NULL;
+  UINTN                              Instance              = 0;
+  EFI_GUID                           *ParameterTypeGuid    = NULL;
+  UINTN                              ParameterClpBlockSize = 0;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK    *ParameterClpBlock    = NULL;
   EFI_PLATFORM_CONFIGURATION_ACTION  ConfigurationAction;
 
   //
@@ -322,7 +332,7 @@ BBTestResponseConformanceAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguration = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -345,7 +355,7 @@ BBTestResponseConformanceAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
@@ -354,7 +364,7 @@ BBTestResponseConformanceAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -367,13 +377,14 @@ BBTestResponseConformanceAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+
+    goto OnExit;
   }
 
   // Assertion Point
 
   // check point 1
-  // invalide controller handle and ChildHandle is NULL
+  // invalid controller handle and ChildHandle is NULL
   // return EFI_INVALID_PARAMETER
   //
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
@@ -381,7 +392,7 @@ BBTestResponseConformanceAutoTest (
                                               PlatformToDriverConfiguration,
                                               NULL,
                                               NULL,
-                                              Instance,
+                                              &Instance,
                                               &ParameterTypeGuid,
                                               (VOID **)&ParameterClpBlock,
                                               &ParameterClpBlockSize
@@ -407,7 +418,7 @@ BBTestResponseConformanceAutoTest (
                                                            PlatformToDriverConfiguration,
                                                            NULL,
                                                            NULL,
-                                                           Instance,
+                                                           &Instance,
                                                            ParameterTypeGuid,
                                                            ParameterClpBlock,
                                                            ParameterClpBlockSize,
@@ -445,7 +456,7 @@ BBTestResponseConformanceAutoTest (
                                            NULL,
                                            &ParameterTypeGuid,
                                            &ParameterClpBlock,
-                                           ParameterClpBlockSize
+                                           &ParameterClpBlockSize
                                            );
       if(Status == EFI_INVALID_PARAMETER) {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
@@ -493,9 +504,17 @@ BBTestResponseConformanceAutoTest (
                );
     }
   */
+
+  Status = EFI_SUCCESS;
+
+OnExit:
   if (CtrlerHandles) {
     SctFreePool (CtrlerHandles);
   }
 
-  return EFI_SUCCESS;
+  if (ParameterClpBlock) {
+    gtBS->FreePool (ParameterClpBlock);
+  }
+
+  return Status;
 }

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PlatformToDriverConfiguration/BlackBoxTest/PlatformToDriverConfigurationBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PlatformToDriverConfiguration/BlackBoxTest/PlatformToDriverConfigurationBBTestFunction.c
@@ -51,14 +51,15 @@ BBTestQueryFunctionAutoTest (
   EFI_STATUS                                     Status;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguration;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   EFI_HANDLE                                     ChildHandle;
-  UINTN                                          *Instance;
+  VOID                                           *ProtocolInstance  = NULL;
+  UINTN                                          Instance           = 0;
   EFI_GUID                                       *ParameterTypeGuid = NULL;
-  UINTN                                          ParameterBlockSize;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK                *ParameterClpBlock;
+  UINTN                                          ParameterBlockSize = 0;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK                *ParameterClpBlock = NULL;
 
   //
   // Get the Standard Library Interface
@@ -80,7 +81,7 @@ BBTestQueryFunctionAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguration = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -109,7 +110,7 @@ BBTestQueryFunctionAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
@@ -118,7 +119,7 @@ BBTestQueryFunctionAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -131,7 +132,8 @@ BBTestQueryFunctionAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+
+    goto OnExit;
   }
 
   // check point
@@ -139,12 +141,14 @@ BBTestQueryFunctionAutoTest (
   //
 
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
+    Instance = 0;
+    Status   = EFI_SUCCESS;
     while (!EFI_ERROR (Status)) {
       Status = PlatformToDriverConfiguration->Query (
                                                 PlatformToDriverConfiguration,
                                                 CtrlerHandles[CtrlerHandleIndex],
                                                 ChildHandle,
-                                                Instance,
+                                                &Instance,
                                                 &ParameterTypeGuid,
                                                 (VOID **)&ParameterClpBlock,
                                                 &ParameterBlockSize
@@ -154,9 +158,9 @@ BBTestQueryFunctionAutoTest (
                                                   PlatformToDriverConfiguration,
                                                   CtrlerHandles[CtrlerHandleIndex],
                                                   ChildHandle,
-                                                  Instance,
+                                                  &Instance,
                                                   ParameterTypeGuid,
-                                                  &ParameterClpBlock,
+                                                  ParameterClpBlock,
                                                   ParameterBlockSize,
                                                   EfiPlatformConfigurationActionNone
                                                   );
@@ -182,11 +186,17 @@ BBTestQueryFunctionAutoTest (
                    );
   }
 
+  Status = EFI_SUCCESS;
+OnExit:
   if (CtrlerHandles) {
     SctFreePool (CtrlerHandles);
   }
 
-  return EFI_SUCCESS;
+  if (ParameterClpBlock) {
+    gtBS->FreePool (ParameterClpBlock);
+  }
+
+  return Status;
 }
 
 /**
@@ -213,14 +223,15 @@ BBTestResponseFunctionAutoTest (
   EFI_STATUS                                     Status;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguration;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   EFI_HANDLE                                     ChildHandle;
-  UINTN                                          *Instance          = 0;
+  VOID                                           *ProtocolInstance  = NULL;
+  UINTN                                          Instance           = 0;
   EFI_GUID                                       *ParameterTypeGuid = NULL;
-  UINTN                                          ParameterBlockSize;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK                *ParameterClpBlock;
+  UINTN                                          ParameterBlockSize = 0;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK                *ParameterClpBlock = NULL;
   EFI_PLATFORM_CONFIGURATION_ACTION              ConfigurationAction;
 
   //
@@ -243,7 +254,7 @@ BBTestResponseFunctionAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguration = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -272,16 +283,18 @@ BBTestResponseFunctionAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+
+    goto OnExit;
   }
 
   //
   // retrieve the protocol Instance
   //
+
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -294,7 +307,7 @@ BBTestResponseFunctionAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // check point
@@ -302,12 +315,14 @@ BBTestResponseFunctionAutoTest (
   //
 
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
+    Instance = 0;
+    Status   = EFI_SUCCESS;
     while (!EFI_ERROR (Status)) {
       Status = PlatformToDriverConfiguration->Query (
                                                 PlatformToDriverConfiguration,
                                                 CtrlerHandles[CtrlerHandleIndex],
                                                 ChildHandle,
-                                                Instance,
+                                                &Instance,
                                                 &ParameterTypeGuid,
                                                 (VOID **)&ParameterClpBlock,
                                                 &ParameterBlockSize
@@ -319,9 +334,9 @@ BBTestResponseFunctionAutoTest (
                                                   PlatformToDriverConfiguration,
                                                   CtrlerHandles[CtrlerHandleIndex],
                                                   ChildHandle,
-                                                  Instance,
+                                                  &Instance,
                                                   ParameterTypeGuid,
-                                                  &ParameterClpBlock,
+                                                  ParameterClpBlock,
                                                   ParameterBlockSize,
                                                   ConfigurationAction
                                                   );
@@ -347,9 +362,15 @@ BBTestResponseFunctionAutoTest (
                    );
   }
 
+  Status = EFI_SUCCESS;
+OnExit:
   if (CtrlerHandles) {
     SctFreePool (CtrlerHandles);
   }
 
-  return EFI_SUCCESS;
+  if (ParameterClpBlock) {
+    gtBS->FreePool (ParameterClpBlock);
+  }
+
+  return Status;
 }

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/PlatformToDriverConfiguration/BlackBoxTest/PlatformToDriverConfigurationBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/PlatformToDriverConfiguration/BlackBoxTest/PlatformToDriverConfigurationBBTestConformance.c
@@ -48,16 +48,17 @@ BBTestQueryConformanceAutoTest (
 {
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL             *StandardLib;
   EFI_STATUS                                     Status;
-  EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguration;
+  EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguration = NULL;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   // EFI_HANDLE                                         ChildHandle;
-  UINTN                            *Instance;
-  EFI_GUID                         *ParameterTypeGuid;
-  UINTN                            ParameterClpBlockSize;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK  *ParameterClpBlock;
+  VOID                             *ProtocolInstance     = NULL;
+  UINTN                            Instance              = 0;
+  EFI_GUID                         *ParameterTypeGuid    = NULL;
+  UINTN                            ParameterClpBlockSize = 0;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK  *ParameterClpBlock    = NULL;
 
   //
   // Get the Standard Library Interface
@@ -79,7 +80,7 @@ BBTestQueryConformanceAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguration = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -102,7 +103,8 @@ BBTestQueryConformanceAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+
+    goto OnExit;
   }
 
   //
@@ -111,7 +113,7 @@ BBTestQueryConformanceAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -124,20 +126,21 @@ BBTestQueryConformanceAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+
+    goto OnExit;
   }
 
   // Assertion Point
 
   // check point 1
-  // EFI_INVALID_PARAMETER returned with ContrllerHandle invalid
+  // EFI_INVALID_PARAMETER returned with ControllerHandle invalid
   //
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
     Status = PlatformToDriverConfiguration->Query (
                                               PlatformToDriverConfiguration,
                                               NULL,
                                               NULL,
-                                              Instance,
+                                              &Instance,
                                               &ParameterTypeGuid,
                                               &ParameterClpBlock,
                                               &ParameterClpBlockSize
@@ -170,7 +173,7 @@ BBTestQueryConformanceAutoTest (
                                          PlatformToDriverConfiguration,
                                          CtrlerHandles[CtrlerHandleIndex],
                                          NULL,
-                                         Instance,
+                                         &Instance,
                                          &ParameterTypeGuid,
                                          NULL,
                                          ParameterClpBlockSize
@@ -202,7 +205,7 @@ BBTestQueryConformanceAutoTest (
                                          PlatformToDriverConfiguration,
                                          CtrlerHandles[CtrlerHandleIndex],
                                          NULL,
-                                         Instance,
+                                         &Instance,
                                          &ParameterTypeGuid,
                                          &ParameterClpBlock,
                                          NULL
@@ -228,7 +231,7 @@ BBTestQueryConformanceAutoTest (
 
   //
   // Check Point 4
-  // Invoke Query() with invalide Instance=NULL
+  // Invoke Query() with invalid Instance=NULL
   // EFI_INVALID_PARAMETER is expected
   //
 
@@ -260,11 +263,17 @@ BBTestQueryConformanceAutoTest (
                    );
   }
 
+  Status = EFI_SUCCESS;
+OnExit:
   if (CtrlerHandles) {
     SctFreePool (CtrlerHandles);
   }
 
-  return EFI_SUCCESS;
+  if (ParameterClpBlock) {
+    gtBS->FreePool (ParameterClpBlock);
+  }
+
+  return Status;
 }
 
 /**
@@ -290,14 +299,15 @@ BBTestResponseConformanceAutoTest (
   EFI_STATUS                                     Status;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguration;
   EFI_TEST_ASSERTION                             AssertionType, RAssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   // EFI_HANDLE                                         ChildHandle;
-  UINTN                              *Instance;
+  VOID                               *ProtocolInstance = NULL;
+  UINTN                              Instance          = 0;
   EFI_GUID                           *ParameterTypeGuid;
   UINTN                              ParameterClpBlockSize;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK    *ParameterClpBlock;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK    *ParameterClpBlock = NULL;
   EFI_PLATFORM_CONFIGURATION_ACTION  ConfigurationAction;
 
   //
@@ -320,7 +330,7 @@ BBTestResponseConformanceAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguration = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -343,7 +353,7 @@ BBTestResponseConformanceAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
@@ -352,7 +362,7 @@ BBTestResponseConformanceAutoTest (
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -365,13 +375,13 @@ BBTestResponseConformanceAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // Assertion Point
 
   // check point 1
-  // invalide controller handle and ChildHandle is NULL
+  // invalid controller handle and ChildHandle is NULL
   // return EFI_INVALID_PARAMETER
   //
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
@@ -379,7 +389,7 @@ BBTestResponseConformanceAutoTest (
                                               PlatformToDriverConfiguration,
                                               NULL,
                                               NULL,
-                                              Instance,
+                                              &Instance,
                                               &ParameterTypeGuid,
                                               &ParameterClpBlock,
                                               &ParameterClpBlockSize
@@ -405,7 +415,7 @@ BBTestResponseConformanceAutoTest (
                                                            PlatformToDriverConfiguration,
                                                            NULL,
                                                            NULL,
-                                                           Instance,
+                                                           &Instance,
                                                            ParameterTypeGuid,
                                                            ParameterClpBlock,
                                                            ParameterClpBlockSize,
@@ -491,9 +501,15 @@ BBTestResponseConformanceAutoTest (
                );
     }
   */
+  Status = EFI_SUCCESS;
+OnExit:
   if (CtrlerHandles) {
     SctFreePool (CtrlerHandles);
   }
 
-  return EFI_SUCCESS;
+  if (ParameterClpBlock) {
+    gtBS->FreePool (ParameterClpBlock);
+  }
+
+  return Status;
 }

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/PlatformToDriverConfiguration/BlackBoxTest/PlatformToDriverConfigurationBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/PlatformToDriverConfiguration/BlackBoxTest/PlatformToDriverConfigurationBBTestFunction.c
@@ -50,14 +50,15 @@ BBTestQueryFunctionAutoTest (
   EFI_STATUS                                     Status;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguration;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   EFI_HANDLE                                     ChildHandle;
-  UINTN                                          *Instance;
+  VOID                                           *ProtocolInstance  = NULL;
+  UINTN                                          Instance           = 0;
   EFI_GUID                                       *ParameterTypeGuid = NULL;
-  UINTN                                          ParameterBlockSize;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK                *ParameterClpBlock;
+  UINTN                                          ParameterBlockSize = 0;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK                *ParameterClpBlock = NULL;
 
   //
   // Get the Standard Library Interface
@@ -79,7 +80,7 @@ BBTestQueryFunctionAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguration = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -108,16 +109,17 @@ BBTestQueryFunctionAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
   // retrieve the protocol Instance
   //
+
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -130,7 +132,7 @@ BBTestQueryFunctionAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // check point
@@ -138,12 +140,14 @@ BBTestQueryFunctionAutoTest (
   //
 
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
+    Instance = 0;
+    Status   = EFI_SUCCESS;
     while (!EFI_ERROR (Status)) {
       Status = PlatformToDriverConfiguration->Query (
                                                 PlatformToDriverConfiguration,
                                                 CtrlerHandles[CtrlerHandleIndex],
                                                 ChildHandle,
-                                                Instance,
+                                                &Instance,
                                                 &ParameterTypeGuid,
                                                 &ParameterClpBlock,
                                                 &ParameterBlockSize
@@ -153,9 +157,9 @@ BBTestQueryFunctionAutoTest (
                                                   PlatformToDriverConfiguration,
                                                   CtrlerHandles[CtrlerHandleIndex],
                                                   ChildHandle,
-                                                  Instance,
+                                                  &Instance,
                                                   ParameterTypeGuid,
-                                                  &ParameterClpBlock,
+                                                  ParameterClpBlock,
                                                   ParameterBlockSize,
                                                   EfiPlatformConfigurationActionNone
                                                   );
@@ -181,11 +185,17 @@ BBTestQueryFunctionAutoTest (
                    );
   }
 
+  Status = EFI_SUCCESS;
+OnExit:
   if (CtrlerHandles) {
     SctFreePool (CtrlerHandles);
   }
 
-  return EFI_SUCCESS;
+  if (ParameterClpBlock) {
+    gtBS->FreePool (ParameterClpBlock);
+  }
+
+  return Status;
 }
 
 /**
@@ -211,14 +221,15 @@ BBTestResponseFunctionAutoTest (
   EFI_STATUS                                     Status;
   EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL  *PlatformToDriverConfiguration;
   EFI_TEST_ASSERTION                             AssertionType;
-  EFI_HANDLE                                     *CtrlerHandles;
+  EFI_HANDLE                                     *CtrlerHandles = NULL;
   UINTN                                          CtrlerHandleNo;
   UINTN                                          CtrlerHandleIndex;
   EFI_HANDLE                                     ChildHandle;
-  UINTN                                          *Instance          = 0;
+  VOID                                           *ProtocolInstance  = NULL;
+  UINTN                                          Instance           = 0;
   EFI_GUID                                       *ParameterTypeGuid = NULL;
   UINTN                                          ParameterBlockSize = 0;
-  EFI_CONFIGURE_CLP_PARAMETER_BLK                *ParameterClpBlock;
+  EFI_CONFIGURE_CLP_PARAMETER_BLK                *ParameterClpBlock = NULL;
   EFI_PLATFORM_CONFIGURATION_ACTION              ConfigurationAction;
 
   //
@@ -241,7 +252,7 @@ BBTestResponseFunctionAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   PlatformToDriverConfiguration = (EFI_PLATFORM_TO_DRIVER_CONFIGURATION_PROTOCOL *)ClientInterface;
@@ -270,16 +281,17 @@ BBTestResponseFunctionAutoTest (
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   //
   // retrieve the protocol Instance
   //
+
   Status = gtBS->LocateProtocol (
                    &gBlackBoxEfiPlatformToDriverConfigurationProtocolGuid,
                    NULL,
-                   (VOID **)&Instance
+                   (VOID **)&ProtocolInstance
                    );
   if ( EFI_ERROR (Status)) {
     StandardLib->RecordAssertion (
@@ -292,7 +304,7 @@ BBTestResponseFunctionAutoTest (
                    __LINE__,
                    Status
                    );
-    return Status;
+    goto OnExit;
   }
 
   // check point
@@ -300,12 +312,14 @@ BBTestResponseFunctionAutoTest (
   //
 
   for (CtrlerHandleIndex = 0; CtrlerHandleIndex < CtrlerHandleNo; CtrlerHandleIndex++) {
+    Instance = 0;
+    Status   = EFI_SUCCESS;
     while (!EFI_ERROR (Status)) {
       Status = PlatformToDriverConfiguration->Query (
                                                 PlatformToDriverConfiguration,
                                                 CtrlerHandles[CtrlerHandleIndex],
                                                 ChildHandle,
-                                                Instance,
+                                                &Instance,
                                                 &ParameterTypeGuid,
                                                 &ParameterClpBlock,
                                                 &ParameterBlockSize
@@ -317,9 +331,9 @@ BBTestResponseFunctionAutoTest (
                                                   PlatformToDriverConfiguration,
                                                   CtrlerHandles[CtrlerHandleIndex],
                                                   ChildHandle,
-                                                  Instance,
+                                                  &Instance,
                                                   ParameterTypeGuid,
-                                                  &ParameterClpBlock,
+                                                  ParameterClpBlock,
                                                   ParameterBlockSize,
                                                   ConfigurationAction
                                                   );
@@ -345,9 +359,15 @@ BBTestResponseFunctionAutoTest (
                    );
   }
 
+  Status = EFI_SUCCESS;
+OnExit:
   if (CtrlerHandles) {
     SctFreePool (CtrlerHandles);
   }
 
-  return EFI_SUCCESS;
+  if (ParameterClpBlock) {
+    gtBS->FreePool (ParameterClpBlock);
+  }
+
+  return Status;
 }


### PR DESCRIPTION
Update the coding style across the PlatformToDriverConfiguration Black Box Test files to align with the project standards. This includes:
- Correcting indentation and spacing for variable declarations and function calls.
- Fixing formatting of control structures (if/else/for) and comments.

Additionally, fix the following functional issues:
- Correct the declaration and usage of ParameterBlockSize to avoid invalid pointer dereference.
- Replace manual GUID comparison with SctCompareGuid() for better reliability.
- Memory leaks in error paths
- Changed UINTN *Instance to UINTN Instance = 0 (value type). Added VOID *ProtocolInstance for LocateProtocol() calls.  This eliminates undefined behavior from dereferencing uninitialized pointers.

fixes: https://github.com/tianocore/edk2-test/issues/302