### PR TITLE
New test scenario of GetVariable() get attributes

### DIFF
--- a/uefi-sct/Doc/TestCaseSpec/04_Services_Runtime_Services_Test.md
+++ b/uefi-sct/Doc/TestCaseSpec/04_Services_Runtime_Services_Test.md
@@ -293,6 +293,31 @@ returned <em>Attributes</em>, <em>Data
 same as the data written
 before.</td>
 </tr>
+<tr class="odd">
+<td id="section-4" class="unnumbered">5.2.1.1.14</td>
+<td
+id="0x74d73827-0xadfe-0x4c4f-0xac-0xc0-0x51-0x2b-0xb9-0x1f-0x01-0x7f"
+class="unnumbered">0x74d73827, 
+0xadfe, 0x4c4f,
+0xac, 0xc0, 
+0x51, 0x2b, 0xb9, 0x1f, 0x01, 0x7f</td>
+<td
+id="rt.getvariable-getvariable-gets-the-existiing-variable-attributes-with-null-data-and-datasize."
+class="unnumbered">RT.GetVariable –
+GetVariable() gets the attributes of the
+existing variable with null Data and DataSize = 0 
+at EFI_TPL_CALLBACK.</td>
+<td
+id="call-setvariable-service-to-insert-a-test-variable.-2.-call-getvariable-service-to-get-the-test-variable-with-attributes.-the-returned-status-must-be-efi_success-and-the-returned-attributes-written-before.-1"
+class="unnumbered">1. Call SetVariable()
+service to insert a test
+variable.
+2. Call GetVariable()
+service with Data = NULL and DataSize =0. 
+The returned status must be EFI_BUFFER_TOO_SMALL and the returned Attributes 
+ must match the attributes set before. <em>Attributes</em> must be
+same as the attributes set before.</td>
+</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
This is a new test scenario of GetVariable() when
Attributes is not NULL. DataSize is 0, Data is NULL

There is a provision in the spec to get only the variable Attributes using the GetVariable() function. This is a case where the data to store the variable is not passed and DataSize is set to 0

This is newly added in UEFI v2.8
Reference: https://mantis.uefi.org/mantis/view.php?id=1954

This is related to Issue: https://github.com/tianocore/edk2-test/issues/260