### PR TITLE
Simple Network Blackbox Test: fix zero MAC address usage

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
@@ -1082,7 +1082,7 @@ BBTestStationAddressFunctionTest (
   //
   SctCopyMem (&BackMacAddress, &SnpInterface->Mode->CurrentAddress, sizeof (EFI_MAC_ADDRESS));
 
-  SctSetMem (&MacAddress, sizeof (EFI_MAC_ADDRESS), 0x0);
+  SctSetMem (&MacAddress, sizeof (EFI_MAC_ADDRESS), 0x2);
   StatusBuf[1] = SnpInterface->StationAddress (SnpInterface, FALSE, &MacAddress);
   CheckPoint2 = SctCompareMem (
                   &SnpInterface->Mode->CurrentAddress,

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
@@ -1017,7 +1017,7 @@ BBTestStationAddressFunctionTest (
   //
   SctCopyMem (&BackMacAddress, &SnpInterface->Mode->CurrentAddress, sizeof (EFI_MAC_ADDRESS));
 
-  SctSetMem (&MacAddress, sizeof (EFI_MAC_ADDRESS), 0x0);
+  SctSetMem (&MacAddress, sizeof (EFI_MAC_ADDRESS), 0x2);
   StatusBuf[1] = SnpInterface->StationAddress (SnpInterface, FALSE, &MacAddress);
   CheckPoint2 = SctCompareMem (
                   &SnpInterface->Mode->CurrentAddress,


### PR DESCRIPTION
Although EDK2 spec does not explicitly limit MAC addresses that may be set using StationAddress(), some drivers reject addresses that are considered by IEEE invalid for individual Ethernet endpoints.
This includes a zero MAC address, as well as multicast addresses. Assigning such addresses to endpoints in real-life scenarios can disrupt network connectivity.

Modify BBTestStationAddressFunctionTest() to use an address 02:02:02... instead of 00:00:00...
MAC addresses that start with 0x2 are considered globally valid as locally administered addresses.