### PR TITLE
uefi-sct: Add EFI_NO_MEDIA conformance check for OpenEx()

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/Guid.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/Guid.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -14,13 +15,13 @@
 **/
 /*++
 
-Module Name:
+ Module Name:
 
-  Guid.c
+   Guid.c
 
-Abstract:
+ Abstract:
 
-  GUIDs auto-generated for EFI test assertion.
+   GUIDs auto-generated for EFI test assertion.
 
 --*/
 
@@ -123,6 +124,8 @@ EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid007 = EFI_TEST_SIMPLEFIL
 EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid008 = EFI_TEST_SIMPLEFILESYSTEMEXCONFORMANCETEST_ASSERTION_008_GUID;
 
 EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid009 = EFI_TEST_SIMPLEFILESYSTEMEXCONFORMANCETEST_ASSERTION_009_GUID;
+
+EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid010 = EFI_TEST_SIMPLEFILESYSTEMEXCONFORMANCETEST_ASSERTION_010_GUID;
 
 
 EFI_GUID gSimpleFileSystemExtensiveTest_AutoAssertionGuid001 = EFI_TEST_SIMPLEFILESYSTEMEXTENSIVETEST_AUTO_ASSERTION_001_GUID;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/Guid.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/Guid.h
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -259,6 +260,11 @@ extern EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid008;
 { 0x12bc7ab7, 0x4ac5, 0x4cf3, {0xa5, 0x54, 0x6b, 0x34, 0xc9, 0x5d, 0xc, 0xea }}
 
 extern EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid009;
+
+#define EFI_TEST_SIMPLEFILESYSTEMEXCONFORMANCETEST_ASSERTION_010_GUID \
+{ 0x7d3a9e2f, 0x1c6b, 0x4a85, {0xb2, 0x0d, 0xe3, 0x4f, 0x8a, 0x16, 0x5c, 0x72 }}
+
+extern EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid010;
 
 
 #define EFI_TEST_SIMPLEFILESYSTEMEXTENSIVETEST_AUTO_ASSERTION_001_GUID \

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -68,6 +69,15 @@ BBTestOpenExConformanceTestCheckpoint2 (
 EFI_STATUS
 EFIAPI
 BBTestOpenExConformanceTestCheckpoint3 (
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib,
+  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL       *SimpleFileSystem
+  );
+
+// TDS 5.2.9.2.4
+
+EFI_STATUS
+EFIAPI
+BBTestOpenExConformanceTestCheckpoint4 (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib,
   EFI_SIMPLE_FILE_SYSTEM_PROTOCOL       *SimpleFileSystem
   );
@@ -187,6 +197,12 @@ BBTestOpenExConformanceTest (
   // 5.2.9.2.3  Call OpenEx() with invalid OpenMode.
   //
   BBTestOpenExConformanceTestCheckpoint3 (StandardLib, SimpleFileSystem);
+
+  //
+  // 5.2.9.2.4  OpenEx() returns EFI_NO_MEDIA when no medium is present.
+  //            Per UEFI 2.10A Mantis 2368.
+  //
+  BBTestOpenExConformanceTestCheckpoint4 (StandardLib, SimpleFileSystem);
 
   return EFI_SUCCESS;
 }
@@ -516,9 +532,11 @@ BBTestOpenExConformanceTestCheckpoint1 (
       if ((EFI_MEDIA_CHANGED == StatusSync)
         || (EFI_WRITE_PROTECTED == StatusSync)
         || (EFI_VOLUME_FULL == StatusSync)
+        || (EFI_NO_MEDIA == StatusSync)
         || (EFI_MEDIA_CHANGED == StatusAsync)
         || (EFI_WRITE_PROTECTED == StatusAsync)
-        || (EFI_VOLUME_FULL == StatusAsync)) {
+        || (EFI_VOLUME_FULL == StatusAsync)
+        || (EFI_NO_MEDIA == StatusAsync)) {
         AssertionType = EFI_TEST_ASSERTION_WARNING;
       }
       
@@ -730,9 +748,11 @@ BBTestOpenExConformanceTestCheckpoint2 (
       if ((EFI_MEDIA_CHANGED == StatusSync)
         || (EFI_WRITE_PROTECTED == StatusSync)
         || (EFI_VOLUME_FULL == StatusSync)
+        || (EFI_NO_MEDIA == StatusSync)
         || (EFI_MEDIA_CHANGED == StatusAsync)
         || (EFI_WRITE_PROTECTED == StatusAsync)
-        || (EFI_VOLUME_FULL == StatusAsync)) {
+        || (EFI_VOLUME_FULL == StatusAsync)
+        || (EFI_NO_MEDIA == StatusAsync)) {
     
         AssertionType = EFI_TEST_ASSERTION_WARNING;
       }
@@ -958,6 +978,125 @@ BBTestOpenExConformanceTestCheckpoint3 (
 }
 
 
+
+
+EFI_STATUS
+EFIAPI
+BBTestOpenExConformanceTestCheckpoint4 (
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib,
+  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL       *SimpleFileSystem
+  )
+{
+  EFI_STATUS                Status;
+  EFI_STATUS                StatusSync;
+  EFI_FILE                  *Root;
+  EFI_TEST_ASSERTION        AssertionType;
+  EFI_FILE                  *FileHandle;
+  EFI_FILE_IO_TOKEN         FileIoTokenSync;
+
+  Root   = NULL;
+  Status = SimpleFileSystem->OpenVolume (SimpleFileSystem, &Root);
+
+  //
+  // Per UEFI 2.10A Mantis 2368: OpenVolume or OpenEx should return
+  // EFI_NO_MEDIA when no medium is present on the device.
+  //
+  if (Status == EFI_NO_MEDIA) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   AssertionType,
+                   gSimpleFileSystemExConformanceTestAssertionGuid010,
+                   L"OpenEx() Conformance Test - checkpoint4 - EFI_NO_MEDIA correctly returned",
+                   L"%a:%d: OpenVolume Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   Status
+                   );
+    return EFI_SUCCESS;
+  }
+
+  if (EFI_ERROR (Status)) {
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   EFI_TEST_ASSERTION_FAILED,
+                   gTestGenericFailureGuid,
+                   L"OpenVolume fail",
+                   L"%a:%d: Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   Status
+                   );
+    return Status;
+  }
+
+  if (Root->Revision != EFI_FILE_PROTOCOL_REVISION2) {
+    Root->Close(Root);
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   EFI_TEST_ASSERTION_FAILED,
+                   gTestGenericFailureGuid,
+                   L"Async File IO is not supported",
+                   L"%a:%d: Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   EFI_UNSUPPORTED
+                   );
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Sync Token Init
+  //
+  FileIoTokenSync.Event  = NULL;
+  FileIoTokenSync.Status = EFI_NOT_READY;
+
+  FileHandle = NULL;
+  StatusSync = Root->OpenEx (
+                       Root,
+                       &FileHandle,
+                       L"BBTestOpenExConformanceTestCheckpoint4_File",
+                       EFI_FILE_MODE_READ,
+                       0,
+                       &FileIoTokenSync
+                       );
+
+  if (StatusSync == EFI_NO_MEDIA) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   AssertionType,
+                   gSimpleFileSystemExConformanceTestAssertionGuid010,
+                   L"OpenEx() Conformance Test - checkpoint4 - EFI_NO_MEDIA returned when no media present",
+                   L"%a:%d: Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   StatusSync
+                   );
+  } else {
+    //
+    // Media is present; EFI_NO_MEDIA condition cannot be tested.
+    //
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   AssertionType,
+                   gSimpleFileSystemExConformanceTestAssertionGuid010,
+                   L"OpenEx() Conformance Test - checkpoint4 - Media present, EFI_NO_MEDIA not testable",
+                   L"%a:%d: Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   StatusSync
+                   );
+  }
+
+  if (FileHandle != NULL) {
+    FileHandle->Close (FileHandle);
+  }
+
+  Root->Close(Root);
+  return EFI_SUCCESS;
+}
 
 
 EFI_STATUS

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/Guid.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/Guid.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -14,13 +15,13 @@
 **/
 /*++
 
-Module Name:
+ Module Name:
 
-  Guid.c
+   Guid.c
 
-Abstract:
+ Abstract:
 
-  GUIDs auto-generated for EFI test assertion.
+   GUIDs auto-generated for EFI test assertion.
 
 --*/
 
@@ -123,6 +124,8 @@ EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid007 = EFI_TEST_SIMPLEFIL
 EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid008 = EFI_TEST_SIMPLEFILESYSTEMEXCONFORMANCETEST_ASSERTION_008_GUID;
 
 EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid009 = EFI_TEST_SIMPLEFILESYSTEMEXCONFORMANCETEST_ASSERTION_009_GUID;
+
+EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid010 = EFI_TEST_SIMPLEFILESYSTEMEXCONFORMANCETEST_ASSERTION_010_GUID;
 
 
 EFI_GUID gSimpleFileSystemExtensiveTest_AutoAssertionGuid001 = EFI_TEST_SIMPLEFILESYSTEMEXTENSIVETEST_AUTO_ASSERTION_001_GUID;

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/Guid.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/Guid.h
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -259,6 +260,11 @@ extern EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid008;
 { 0x12bc7ab7, 0x4ac5, 0x4cf3, 0xa5, 0x54, 0x6b, 0x34, 0xc9, 0x5d, 0xc, 0xea }
 
 extern EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid009;
+
+#define EFI_TEST_SIMPLEFILESYSTEMEXCONFORMANCETEST_ASSERTION_010_GUID \
+{ 0x7d3a9e2f, 0x1c6b, 0x4a85, 0xb2, 0x0d, 0xe3, 0x4f, 0x8a, 0x16, 0x5c, 0x72 }
+
+extern EFI_GUID gSimpleFileSystemExConformanceTestAssertionGuid010;
 
 
 #define EFI_TEST_SIMPLEFILESYSTEMEXTENSIVETEST_AUTO_ASSERTION_001_GUID \

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2016 Unified EFI, Inc.<BR>
   Copyright (c) 2013 - 2016, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -65,6 +66,14 @@ BBTestOpenExConformanceTestCheckpoint2 (
 
 EFI_STATUS
 BBTestOpenExConformanceTestCheckpoint3 (
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib,
+  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL       *SimpleFileSystem
+  );
+
+// TDS 5.2.9.2.4
+
+EFI_STATUS
+BBTestOpenExConformanceTestCheckpoint4 (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib,
   EFI_SIMPLE_FILE_SYSTEM_PROTOCOL       *SimpleFileSystem
   );
@@ -177,6 +186,12 @@ BBTestOpenExConformanceTest (
   // 5.2.9.2.3  Call OpenEx() with invalid OpenMode.
   //
   BBTestOpenExConformanceTestCheckpoint3 (StandardLib, SimpleFileSystem);
+
+  //
+  // 5.2.9.2.4  OpenEx() returns EFI_NO_MEDIA when no medium is present.
+  //            Per UEFI 2.10A Mantis 2368.
+  //
+  BBTestOpenExConformanceTestCheckpoint4 (StandardLib, SimpleFileSystem);
 
   return EFI_SUCCESS;
 }
@@ -502,9 +517,11 @@ BBTestOpenExConformanceTestCheckpoint1 (
       if ((EFI_MEDIA_CHANGED == StatusSync)
         || (EFI_WRITE_PROTECTED == StatusSync)
         || (EFI_VOLUME_FULL == StatusSync)
+        || (EFI_NO_MEDIA == StatusSync)
         || (EFI_MEDIA_CHANGED == StatusAsync)
         || (EFI_WRITE_PROTECTED == StatusAsync)
-        || (EFI_VOLUME_FULL == StatusAsync)) {
+        || (EFI_VOLUME_FULL == StatusAsync)
+        || (EFI_NO_MEDIA == StatusAsync)) {
         AssertionType = EFI_TEST_ASSERTION_WARNING;
       }
       
@@ -715,9 +732,11 @@ BBTestOpenExConformanceTestCheckpoint2 (
       if ((EFI_MEDIA_CHANGED == StatusSync)
         || (EFI_WRITE_PROTECTED == StatusSync)
         || (EFI_VOLUME_FULL == StatusSync)
+        || (EFI_NO_MEDIA == StatusSync)
         || (EFI_MEDIA_CHANGED == StatusAsync)
         || (EFI_WRITE_PROTECTED == StatusAsync)
-        || (EFI_VOLUME_FULL == StatusAsync)) {
+        || (EFI_VOLUME_FULL == StatusAsync)
+        || (EFI_NO_MEDIA == StatusAsync)) {
     
         AssertionType = EFI_TEST_ASSERTION_WARNING;
       }
@@ -942,6 +961,122 @@ BBTestOpenExConformanceTestCheckpoint3 (
 }
 
 
+EFI_STATUS
+BBTestOpenExConformanceTestCheckpoint4 (
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib,
+  EFI_SIMPLE_FILE_SYSTEM_PROTOCOL       *SimpleFileSystem
+  )
+{
+  EFI_STATUS                Status;
+  EFI_STATUS                StatusSync;
+  EFI_FILE                  *Root;
+  EFI_TEST_ASSERTION        AssertionType;
+  EFI_FILE                  *FileHandle;
+  EFI_FILE_IO_TOKEN         FileIoTokenSync;
+
+  Root   = NULL;
+  Status = SimpleFileSystem->OpenVolume (SimpleFileSystem, &Root);
+
+  //
+  // Per UEFI 2.10A Mantis 2368: OpenVolume or OpenEx should return
+  // EFI_NO_MEDIA when no medium is present on the device.
+  //
+  if (Status == EFI_NO_MEDIA) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   AssertionType,
+                   gSimpleFileSystemExConformanceTestAssertionGuid010,
+                   L"OpenEx() Conformance Test - checkpoint4 - EFI_NO_MEDIA correctly returned",
+                   L"%a:%d: OpenVolume Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   Status
+                   );
+    return EFI_SUCCESS;
+  }
+
+  if (EFI_ERROR (Status)) {
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   EFI_TEST_ASSERTION_FAILED,
+                   gTestGenericFailureGuid,
+                   L"OpenVolume fail",
+                   L"%a:%d: Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   Status
+                   );
+    return Status;
+  }
+
+  if (Root->Revision != EFI_FILE_PROTOCOL_REVISION2) {
+    Root->Close(Root);
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   EFI_TEST_ASSERTION_FAILED,
+                   gTestGenericFailureGuid,
+                   L"Async File IO is not supported",
+                   L"%a:%d: Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   EFI_UNSUPPORTED
+                   );
+    return EFI_UNSUPPORTED;
+  }
+
+  //
+  // Sync Token Init
+  //
+  FileIoTokenSync.Event  = NULL;
+  FileIoTokenSync.Status = EFI_NOT_READY;
+
+  FileHandle = NULL;
+  StatusSync = Root->OpenEx (
+                       Root,
+                       &FileHandle,
+                       L"BBTestOpenExConformanceTestCheckpoint4_File",
+                       EFI_FILE_MODE_READ,
+                       0,
+                       &FileIoTokenSync
+                       );
+
+  if (StatusSync == EFI_NO_MEDIA) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   AssertionType,
+                   gSimpleFileSystemExConformanceTestAssertionGuid010,
+                   L"OpenEx() Conformance Test - checkpoint4 - EFI_NO_MEDIA returned when no media present",
+                   L"%a:%d: Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   StatusSync
+                   );
+  } else {
+    //
+    // Media is present; EFI_NO_MEDIA condition cannot be tested.
+    //
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   AssertionType,
+                   gSimpleFileSystemExConformanceTestAssertionGuid010,
+                   L"OpenEx() Conformance Test - checkpoint4 - Media present, EFI_NO_MEDIA not testable",
+                   L"%a:%d: Status - %r",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   StatusSync
+                   );
+  }
+
+  if (FileHandle != NULL) {
+    FileHandle->Close (FileHandle);
+  }
+
+  Root->Close(Root);
+  return EFI_SUCCESS;
+}
 
 
 EFI_STATUS


### PR DESCRIPTION
UEFI Specification 2.10 Errata A (Mantis 2368) corrected mixed-up error
codes for EFI_FILE_PROTOCOL.OpenEx() and added EFI_NO_MEDIA as a valid
return status when the device contains no medium.

Update existing OpenEx conformance checkpoints 1 and 2 to treat
EFI_NO_MEDIA as a WARNING outcome, matching the existing treatment of
EFI_MEDIA_CHANGED, EFI_WRITE_PROTECTED, and EFI_VOLUME_FULL.

Add new conformance checkpoint 4 that explicitly validates EFI_NO_MEDIA
behavior by calling OpenVolume and OpenEx on devices without media
present. If media is present, the test records WARNING since the
no-media condition cannot be exercised.

Add new assertion GUID for the new checkpoint. Mirror all changes to
both EFI and IHV test paths.

### Files Changed

- `uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c`
- `uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/Guid.h`
- `uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/Guid.c`
- `uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestConformance.c`
- `uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/Guid.h`
- `uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/Guid.c`

### References

- Mantis 2368: https://mantis.uefi.org/mantis/view.php?id=2368
- Fixes https://github.com/tianocore/edk2-test/issues/319

Made with [Cursor](https://cursor.com)