### PR TITLE
uefi-sct: Fix Efi.h build failure with modern edk2 Base.h

### DIFF
--- a/uefi-sct/SctPkg/Include/Efi.h
+++ b/uefi-sct/SctPkg/Include/Efi.h
@@ -2,6 +2,7 @@
 
   Copyright 2006 - 2015 Unified EFI, Inc.<BR>
   Copyright (c) 2010 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 
   This program and the accompanying materials
   are licensed and made available under the terms and conditions of the BSD License
@@ -29,8 +30,14 @@ Abstract:
 #ifndef _EFI_H_
 #define _EFI_H_
 
-// If we use the new build system
-#ifndef __BASE_H__
+// If we use the new build system.
+// Note: older edk2 Base.h used #define __BASE_H__ as its include guard;
+// modern edk2 uses #pragma once, so __BASE_H__ is no longer defined.
+// Check for MDE_CPU_* from ProcessorBind.h (always included by Base.h)
+// as a reliable indicator of the modern build system.
+#if !defined(__BASE_H__) && !defined(MDE_CPU_IA32) && !defined(MDE_CPU_X64) && \
+    !defined(MDE_CPU_EBC) && !defined(MDE_CPU_ARM) && !defined(MDE_CPU_AARCH64) && \
+    !defined(MDE_CPU_RISCV64) && !defined(MDE_CPU_LOONGARCH64)
   #include "Tiano.h"
   #include "PeiHob.h"
 


### PR DESCRIPTION
## Summary

Fixes #343 — Build fails with modern edk2 due to `Tiano.h` not found.

Modern edk2 `Base.h` switched from `#define __BASE_H__` include guards to `#pragma once`. `SctPkg/Include/Efi.h` uses `#ifndef __BASE_H__` to detect the build system, but since the macro is no longer defined, it falls into the legacy code path and tries to include the non-existent `Tiano.h`.

## Changes

- Updated the preprocessor guard in `SctPkg/Include/Efi.h` to also check for `MDE_CPU_*` macros from `ProcessorBind.h` (always included by `Base.h`), covering all supported architectures
- Backward compatible with older edk2 that still defines `__BASE_H__`

## Test Plan

- [x] Verified `RestExBBTest.efi` module compiles successfully with `build -p SctPkg/UEFI/UEFI_SCT.dsc -t GCC -a X64`
- [ ] Full SCT build on X64
- [ ] Full SCT build on AARCH64
- [ ] Full SCT build on RISCV64

Signed-off-by: Carolyn Gjertsen <Carolyn.Gjertsen@amd.com>