### PR TITLE
[New Test Coverage] SctPkg/RedfishDiscoverBBTest: Add EFI_REDFISH_DISCOVER_PROTOCOL black-box tests (Mantis 1920, 1925, 2172)

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RedfishDiscover/BlackBoxTest/Guid.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RedfishDiscover/BlackBoxTest/Guid.c
@@ -1,0 +1,53 @@
+/** @file
+
+  Copyright 2006 - 2026 Unified EFI, Inc.<BR>
+  Copyright (c) 2026, AMD Corporation. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+ Module Name:
+
+   Guid.c
+
+ Abstract:
+
+   GUIDs for EFI Redfish Discover Protocol test assertion.
+
+--*/
+#include "Efi.h"
+#include "Guid.h"
+
+EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid001 = EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_001_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid002 = EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_002_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid003 = EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_003_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid004 = EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_004_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid005 = EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_005_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid006 = EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_006_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid007 = EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_007_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid008 = EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_008_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid001 = EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_001_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid002 = EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_002_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid003 = EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_003_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid004 = EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_004_GUID;
+
+EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid005 = EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_005_GUID;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RedfishDiscover/BlackBoxTest/Guid.h
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RedfishDiscover/BlackBoxTest/Guid.h
@@ -1,0 +1,111 @@
+/** @file
+
+  Copyright 2006 - 2026 Unified EFI, Inc.<BR>
+  Copyright (c) 2026, AMD Corporation. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+ Module Name:
+
+   Guid.h
+
+ Abstract:
+
+   GUIDs for EFI Redfish Discover Protocol test assertion.
+
+--*/
+
+//
+// Conformance Assertion GUIDs
+//
+
+// GetNetworkInterfaceList() with NULL NumberOfNetworkInterfaces
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_001_GUID \
+{ 0xa1b2c3d4, 0xe5f6, 0x4a01, { 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18, 0x29 } }
+
+extern EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid001;
+
+// GetNetworkInterfaceList() with NULL NetworkInterfaces
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_002_GUID \
+{ 0xb2c3d4e5, 0xf607, 0x4b12, { 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18, 0x29, 0x3a } }
+
+extern EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid002;
+
+// AcquireRedfishService() with NULL Token
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_003_GUID \
+{ 0xc3d4e5f6, 0x0718, 0x4c23, { 0xd4, 0xe5, 0xf6, 0x07, 0x18, 0x29, 0x3a, 0x4b } }
+
+extern EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid003;
+
+// AcquireRedfishService() with Flags == 0
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_004_GUID \
+{ 0xd4e5f607, 0x1829, 0x4d34, { 0xe5, 0xf6, 0x07, 0x18, 0x29, 0x3a, 0x4b, 0x5c } }
+
+extern EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid004;
+
+// ReleaseRedfishService() with NULL List
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_005_GUID \
+{ 0xe5f60718, 0x293a, 0x4e45, { 0xf6, 0x07, 0x18, 0x29, 0x3a, 0x4b, 0x5c, 0x6d } }
+
+extern EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid005;
+
+// AcquireRedfishService() with Flags == EFI_REDFISH_DISCOVER_VALIDATION only (Mantis 2172)
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_006_GUID \
+{ 0x4b5c6d7e, 0x8f90, 0x4a56, { 0x07, 0x18, 0x29, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e } }
+
+extern EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid006;
+
+// GetNetworkInterfaceList() with NULL ImageHandle (Mantis 2172)
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_007_GUID \
+{ 0x5c6d7e8f, 0x90a1, 0x4b67, { 0x18, 0x29, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e, 0x8f } }
+
+extern EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid007;
+
+// AcquireRedfishService() with NULL ImageHandle (Mantis 2172)
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTCONFORMANCE_ASSERTION_008_GUID \
+{ 0x6d7e8f90, 0xa1b2, 0x4c78, { 0x29, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e, 0x8f, 0xa0 } }
+
+extern EFI_GUID gRedfishDiscoverBBTestConformanceAssertionGuid008;
+
+//
+// Function Assertion GUIDs
+//
+
+// GetNetworkInterfaceList() returns valid interface list
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_001_GUID \
+{ 0xf6071829, 0x3a4b, 0x4f56, { 0x07, 0x18, 0x29, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e } }
+
+extern EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid001;
+
+// GetNetworkInterfaceList() NumberOfNetworkInterfaces is consistent
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_002_GUID \
+{ 0x0718293a, 0x4b5c, 0x4067, { 0x18, 0x29, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e, 0x8f } }
+
+extern EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid002;
+
+// AcquireRedfishService() with valid parameters
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_003_GUID \
+{ 0x18293a4b, 0x5c6d, 0x4178, { 0x29, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e, 0x8f, 0x90 } }
+
+extern EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid003;
+
+// AbortAcquireRedfishService() basic call
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_004_GUID \
+{ 0x293a4b5c, 0x6d7e, 0x4289, { 0x3a, 0x4b, 0x5c, 0x6d, 0x7e, 0x8f, 0x90, 0xa1 } }
+
+extern EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid004;
+
+// ReleaseRedfishService() basic call
+#define EFI_TEST_REDFISH_DISCOVER_BBTESTFUNCTION_ASSERTION_005_GUID \
+{ 0x3a4b5c6d, 0x7e8f, 0x439a, { 0x4b, 0x5c, 0x6d, 0x7e, 0x8f, 0x90, 0xa1, 0xb2 } }
+
+extern EFI_GUID gRedfishDiscoverBBTestFunctionAssertionGuid005;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RedfishDiscover/BlackBoxTest/RedfishDiscoverBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RedfishDiscover/BlackBoxTest/RedfishDiscoverBBTestConformance.c
@@ -1,0 +1,377 @@
+/** @file
+
+  Copyright 2006 - 2026 Unified EFI, Inc.<BR>
+  Copyright (c) 2026, AMD Corporation. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  RedfishDiscoverBBTestConformance.c
+
+Abstract:
+
+  Conformance test cases for EFI_REDFISH_DISCOVER_PROTOCOL
+
+  Covers invalid parameter handling for all four protocol functions
+  per UEFI 2.8 (Mantis 1920) with clarifications from Mantis 1925
+  and revised definitions from UEFI 2.8C (Mantis 2172).
+
+--*/
+
+#include "RedfishDiscoverBBTestMain.h"
+#include "SctLib.h"
+
+extern EFI_HANDLE mImageHandle;
+
+EFI_STATUS
+EFIAPI
+BBTestGetNetworkInterfaceListConformanceTest (
+  IN EFI_BB_TEST_PROTOCOL       *This,
+  IN VOID                       *ClientInterface,
+  IN EFI_TEST_LEVEL             TestLevel,
+  IN EFI_HANDLE                 SupportHandle
+  )
+{
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL          *StandardLib;
+  EFI_STATUS                                  Status;
+  EFI_REDFISH_DISCOVER_PROTOCOL               *RedfishDiscover;
+  EFI_TEST_ASSERTION                          AssertionType;
+  UINTN                                       NumberOfNetworkInterfaces;
+  EFI_REDFISH_DISCOVER_NETWORK_INTERFACE      *NetworkInterfaces;
+
+  RedfishDiscover = (EFI_REDFISH_DISCOVER_PROTOCOL *)ClientInterface;
+
+  Status = gtBS->HandleProtocol (
+                   SupportHandle,
+                   &gEfiStandardTestLibraryGuid,
+                   (VOID **)&StandardLib
+                   );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Checkpoint 1: GetNetworkInterfaceList() with NULL NumberOfNetworkInterfaces
+  //
+  NetworkInterfaces = NULL;
+  Status = RedfishDiscover->GetNetworkInterfaceList (
+                              RedfishDiscover,
+                              mImageHandle,
+                              NULL,
+                              &NetworkInterfaces
+                              );
+
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestConformanceAssertionGuid001,
+                 L"REDFISH_DISCOVER.GetNetworkInterfaceList - NULL NumberOfNetworkInterfaces returns EFI_INVALID_PARAMETER",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // Checkpoint 2: GetNetworkInterfaceList() with NULL NetworkInterfaces
+  //
+  NumberOfNetworkInterfaces = 0;
+  Status = RedfishDiscover->GetNetworkInterfaceList (
+                              RedfishDiscover,
+                              mImageHandle,
+                              &NumberOfNetworkInterfaces,
+                              NULL
+                              );
+
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestConformanceAssertionGuid002,
+                 L"REDFISH_DISCOVER.GetNetworkInterfaceList - NULL NetworkInterfaces returns EFI_INVALID_PARAMETER",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // Checkpoint 3: GetNetworkInterfaceList() with NULL ImageHandle.
+  // Per Mantis 2172, ImageHandle == NULL should return EFI_INVALID_PARAMETER.
+  //
+  NumberOfNetworkInterfaces = 0;
+  NetworkInterfaces = NULL;
+  Status = RedfishDiscover->GetNetworkInterfaceList (
+                              RedfishDiscover,
+                              NULL,
+                              &NumberOfNetworkInterfaces,
+                              &NetworkInterfaces
+                              );
+
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestConformanceAssertionGuid007,
+                 L"REDFISH_DISCOVER.GetNetworkInterfaceList - NULL ImageHandle returns EFI_INVALID_PARAMETER",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+BBTestAcquireRedfishServiceConformanceTest (
+  IN EFI_BB_TEST_PROTOCOL       *This,
+  IN VOID                       *ClientInterface,
+  IN EFI_TEST_LEVEL             TestLevel,
+  IN EFI_HANDLE                 SupportHandle
+  )
+{
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL          *StandardLib;
+  EFI_STATUS                                  Status;
+  EFI_REDFISH_DISCOVER_PROTOCOL               *RedfishDiscover;
+  EFI_TEST_ASSERTION                          AssertionType;
+  EFI_REDFISH_DISCOVERED_TOKEN                Token;
+
+  RedfishDiscover = (EFI_REDFISH_DISCOVER_PROTOCOL *)ClientInterface;
+
+  Status = gtBS->HandleProtocol (
+                   SupportHandle,
+                   &gEfiStandardTestLibraryGuid,
+                   (VOID **)&StandardLib
+                   );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Checkpoint 1: AcquireRedfishService() with NULL Token.
+  // Per spec, Token == NULL should return EFI_INVALID_PARAMETER.
+  //
+  Status = RedfishDiscover->AcquireRedfishService (
+                              RedfishDiscover,
+                              mImageHandle,
+                              NULL,
+                              EFI_REDFISH_DISCOVER_HOST_INTERFACE,
+                              NULL
+                              );
+
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestConformanceAssertionGuid003,
+                 L"REDFISH_DISCOVER.AcquireRedfishService - NULL Token returns EFI_INVALID_PARAMETER",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // Checkpoint 2: AcquireRedfishService() with Flags == 0.
+  // Per spec, Flags == 0 should return EFI_INVALID_PARAMETER.
+  //
+  SctZeroMem (&Token, sizeof (EFI_REDFISH_DISCOVERED_TOKEN));
+  Token.Signature = REDFISH_DISCOVER_TOKEN_SIGNATURE;
+  Token.Timeout = 0;
+  Token.Event = NULL;
+
+  Status = RedfishDiscover->AcquireRedfishService (
+                              RedfishDiscover,
+                              mImageHandle,
+                              NULL,
+                              0,
+                              &Token
+                              );
+
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestConformanceAssertionGuid004,
+                 L"REDFISH_DISCOVER.AcquireRedfishService - Flags == 0 returns EFI_INVALID_PARAMETER",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // Checkpoint 3: AcquireRedfishService() with Flags == EFI_REDFISH_DISCOVER_VALIDATION only.
+  // Per Mantis 2172, the VALIDATION bit is a modifier, not a discovery method.
+  // (Flags & ~EFI_REDFISH_DISCOVER_VALIDATION) == 0 should return EFI_INVALID_PARAMETER.
+  //
+  SctZeroMem (&Token, sizeof (EFI_REDFISH_DISCOVERED_TOKEN));
+  Token.Signature = REDFISH_DISCOVER_TOKEN_SIGNATURE;
+  Token.Timeout = 0;
+  Token.Event = NULL;
+
+  Status = RedfishDiscover->AcquireRedfishService (
+                              RedfishDiscover,
+                              mImageHandle,
+                              NULL,
+                              EFI_REDFISH_DISCOVER_VALIDATION,
+                              &Token
+                              );
+
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestConformanceAssertionGuid006,
+                 L"REDFISH_DISCOVER.AcquireRedfishService - VALIDATION-only Flags returns EFI_INVALID_PARAMETER",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // Checkpoint 4: AcquireRedfishService() with NULL ImageHandle.
+  // Per Mantis 2172, ImageHandle == NULL should return EFI_INVALID_PARAMETER.
+  //
+  SctZeroMem (&Token, sizeof (EFI_REDFISH_DISCOVERED_TOKEN));
+  Token.Signature = REDFISH_DISCOVER_TOKEN_SIGNATURE;
+  Token.Timeout = 0;
+  Token.Event = NULL;
+
+  Status = RedfishDiscover->AcquireRedfishService (
+                              RedfishDiscover,
+                              NULL,
+                              NULL,
+                              EFI_REDFISH_DISCOVER_HOST_INTERFACE,
+                              &Token
+                              );
+
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestConformanceAssertionGuid008,
+                 L"REDFISH_DISCOVER.AcquireRedfishService - NULL ImageHandle returns EFI_INVALID_PARAMETER",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+BBTestReleaseRedfishServiceConformanceTest (
+  IN EFI_BB_TEST_PROTOCOL       *This,
+  IN VOID                       *ClientInterface,
+  IN EFI_TEST_LEVEL             TestLevel,
+  IN EFI_HANDLE                 SupportHandle
+  )
+{
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL          *StandardLib;
+  EFI_STATUS                                  Status;
+  EFI_REDFISH_DISCOVER_PROTOCOL               *RedfishDiscover;
+  EFI_TEST_ASSERTION                          AssertionType;
+
+  RedfishDiscover = (EFI_REDFISH_DISCOVER_PROTOCOL *)ClientInterface;
+
+  Status = gtBS->HandleProtocol (
+                   SupportHandle,
+                   &gEfiStandardTestLibraryGuid,
+                   (VOID **)&StandardLib
+                   );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Checkpoint 1: ReleaseRedfishService() with NULL List
+  //
+  Status = RedfishDiscover->ReleaseRedfishService (RedfishDiscover, NULL);
+
+  if (Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestConformanceAssertionGuid005,
+                 L"REDFISH_DISCOVER.ReleaseRedfishService - NULL List returns EFI_INVALID_PARAMETER",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  return EFI_SUCCESS;
+}

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RedfishDiscover/BlackBoxTest/RedfishDiscoverBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/RedfishDiscover/BlackBoxTest/RedfishDiscoverBBTestFunction.c
@@ -1,0 +1,284 @@
+/** @file
+
+  Copyright 2006 - 2026 Unified EFI, Inc.<BR>
+  Copyright (c) 2026, AMD Corporation. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  RedfishDiscoverBBTestFunction.c
+
+Abstract:
+
+  Function test cases for EFI_REDFISH_DISCOVER_PROTOCOL
+
+  Covers all four protocol functions per UEFI 2.8 (Mantis 1920) with
+  clarifications from Mantis 1925 and revised definitions from
+  UEFI 2.8C (Mantis 2172).
+
+--*/
+
+#include "RedfishDiscoverBBTestMain.h"
+#include "SctLib.h"
+
+extern EFI_HANDLE mImageHandle;
+
+EFI_STATUS
+EFIAPI
+BBTestGetNetworkInterfaceListFunctionTest (
+  IN EFI_BB_TEST_PROTOCOL       *This,
+  IN VOID                       *ClientInterface,
+  IN EFI_TEST_LEVEL             TestLevel,
+  IN EFI_HANDLE                 SupportHandle
+  )
+{
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL          *StandardLib;
+  EFI_STATUS                                  Status;
+  EFI_REDFISH_DISCOVER_PROTOCOL               *RedfishDiscover;
+  EFI_TEST_ASSERTION                          AssertionType;
+  UINTN                                       NumberOfNetworkInterfaces;
+  EFI_REDFISH_DISCOVER_NETWORK_INTERFACE      *NetworkInterfaces;
+
+  RedfishDiscover = (EFI_REDFISH_DISCOVER_PROTOCOL *)ClientInterface;
+
+  Status = gtBS->HandleProtocol (
+                   SupportHandle,
+                   &gEfiStandardTestLibraryGuid,
+                   (VOID **)&StandardLib
+                   );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  NumberOfNetworkInterfaces = 0;
+  NetworkInterfaces = NULL;
+
+  //
+  // Checkpoint 1: GetNetworkInterfaceList() with valid parameters.
+  // Should return EFI_SUCCESS with a list of NICs capable of Redfish
+  // discovery, or EFI_NOT_FOUND if no interfaces are available.
+  //
+  Status = RedfishDiscover->GetNetworkInterfaceList (
+                              RedfishDiscover,
+                              mImageHandle,
+                              &NumberOfNetworkInterfaces,
+                              &NetworkInterfaces
+                              );
+
+  if (Status == EFI_SUCCESS && NetworkInterfaces != NULL) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_NOT_FOUND || Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestFunctionAssertionGuid001,
+                 L"REDFISH_DISCOVER.GetNetworkInterfaceList - returns valid interface list",
+                 L"%a:%d: Status - %r, Count - %d",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status,
+                 NumberOfNetworkInterfaces
+                 );
+
+  //
+  // Checkpoint 2: If successful, verify NumberOfNetworkInterfaces > 0.
+  //
+  if (Status == EFI_SUCCESS) {
+    if (NumberOfNetworkInterfaces > 0 && NetworkInterfaces != NULL) {
+      AssertionType = EFI_TEST_ASSERTION_PASSED;
+    } else {
+      AssertionType = EFI_TEST_ASSERTION_FAILED;
+    }
+
+    StandardLib->RecordAssertion (
+                   StandardLib,
+                   AssertionType,
+                   gRedfishDiscoverBBTestFunctionAssertionGuid002,
+                   L"REDFISH_DISCOVER.GetNetworkInterfaceList - NumberOfNetworkInterfaces is consistent",
+                   L"%a:%d: Count - %d, Pointer - 0x%p",
+                   __FILE__,
+                   (UINTN)__LINE__,
+                   NumberOfNetworkInterfaces,
+                   NetworkInterfaces
+                   );
+
+    gtBS->FreePool (NetworkInterfaces);
+  }
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+BBTestAcquireRedfishServiceFunctionTest (
+  IN EFI_BB_TEST_PROTOCOL       *This,
+  IN VOID                       *ClientInterface,
+  IN EFI_TEST_LEVEL             TestLevel,
+  IN EFI_HANDLE                 SupportHandle
+  )
+{
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL          *StandardLib;
+  EFI_STATUS                                  Status;
+  EFI_REDFISH_DISCOVER_PROTOCOL               *RedfishDiscover;
+  EFI_TEST_ASSERTION                          AssertionType;
+  EFI_REDFISH_DISCOVERED_TOKEN                Token;
+
+  RedfishDiscover = (EFI_REDFISH_DISCOVER_PROTOCOL *)ClientInterface;
+
+  Status = gtBS->HandleProtocol (
+                   SupportHandle,
+                   &gEfiStandardTestLibraryGuid,
+                   (VOID **)&StandardLib
+                   );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Checkpoint 1: AcquireRedfishService() synchronous discovery.
+  // Set Timeout to 0 for synchronous mode. A real Redfish service may
+  // not be present; EFI_NOT_FOUND and EFI_TIMEOUT are acceptable.
+  //
+  SctZeroMem (&Token, sizeof (EFI_REDFISH_DISCOVERED_TOKEN));
+  Token.Signature = REDFISH_DISCOVER_TOKEN_SIGNATURE;
+  Token.Timeout = 0;
+  Token.Event = NULL;
+
+  Status = RedfishDiscover->AcquireRedfishService (
+                              RedfishDiscover,
+                              mImageHandle,
+                              NULL,
+                              EFI_REDFISH_DISCOVER_HOST_INTERFACE,
+                              &Token
+                              );
+
+  if (Status == EFI_SUCCESS) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_NOT_FOUND ||
+             Status == EFI_TIMEOUT ||
+             Status == EFI_UNSUPPORTED ||
+             Status == EFI_DEVICE_ERROR ||
+             Status == EFI_INVALID_PARAMETER) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestFunctionAssertionGuid003,
+                 L"REDFISH_DISCOVER.AcquireRedfishService - synchronous discovery via host interface",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  if (Status == EFI_SUCCESS && Token.DiscoverList.NumberOfServiceFound > 0) {
+    RedfishDiscover->ReleaseRedfishService (
+                       RedfishDiscover,
+                       &Token.DiscoverList
+                       );
+  }
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+BBTestAbortAndReleaseFunctionTest (
+  IN EFI_BB_TEST_PROTOCOL       *This,
+  IN VOID                       *ClientInterface,
+  IN EFI_TEST_LEVEL             TestLevel,
+  IN EFI_HANDLE                 SupportHandle
+  )
+{
+  EFI_STANDARD_TEST_LIBRARY_PROTOCOL          *StandardLib;
+  EFI_STATUS                                  Status;
+  EFI_REDFISH_DISCOVER_PROTOCOL               *RedfishDiscover;
+  EFI_TEST_ASSERTION                          AssertionType;
+  EFI_REDFISH_DISCOVERED_LIST                 EmptyList;
+
+  RedfishDiscover = (EFI_REDFISH_DISCOVER_PROTOCOL *)ClientInterface;
+
+  Status = gtBS->HandleProtocol (
+                   SupportHandle,
+                   &gEfiStandardTestLibraryGuid,
+                   (VOID **)&StandardLib
+                   );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Checkpoint 1: AbortAcquireRedfishService() with NULL target interface
+  // (abort on all interfaces). When no discovery is in progress,
+  // EFI_NOT_FOUND or EFI_UNSUPPORTED is acceptable.
+  //
+  Status = RedfishDiscover->AbortAcquireRedfishService (RedfishDiscover, NULL);
+
+  if (Status == EFI_SUCCESS) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_NOT_FOUND || Status == EFI_UNSUPPORTED) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestFunctionAssertionGuid004,
+                 L"REDFISH_DISCOVER.AbortAcquireRedfishService - abort with NULL target",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  //
+  // Checkpoint 2: ReleaseRedfishService() with an empty list.
+  // Per spec, the list was allocated by Acquire() — passing an empty
+  // but non-NULL list should succeed or return a benign error.
+  //
+  SctZeroMem (&EmptyList, sizeof (EFI_REDFISH_DISCOVERED_LIST));
+
+  Status = RedfishDiscover->ReleaseRedfishService (RedfishDiscover, &EmptyList);
+
+  if (Status == EFI_SUCCESS) {
+    AssertionType = EFI_TEST_ASSERTION_PASSED;
+  } else if (Status == EFI_INVALID_PARAMETER || Status == EFI_NOT_FOUND) {
+    AssertionType = EFI_TEST_ASSERTION_WARNING;
+  } else {
+    AssertionType = EFI_TEST_ASSERTION_FAILED;
+  }
+
+  StandardLib->RecordAssertion (
+                 StandardLib,
+                 AssertionType,
+                 gRedfishDiscoverBBTestFunctionAssertionGuid005,
+                 L"REDFISH_DISCOVER.ReleaseRedfishService - release empty list",
+                 L"%a:%d: Status - %r",
+                 __FILE__,
+                 (UINTN)__LINE__,
+                 Status
+                 );
+
+  return EFI_SUCCESS;
+}

--- a/uefi-sct/SctPkg/UEFI/Protocol/RedfishDiscover.h
+++ b/uefi-sct/SctPkg/UEFI/Protocol/RedfishDiscover.h
@@ -1,0 +1,33 @@
+/** @file
+
+  Copyright 2006 - 2026 Unified EFI, Inc.<BR>
+  Copyright (c) 2026, AMD Corporation. All rights reserved.<BR>
+
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+
+**/
+/*++
+
+Module Name:
+
+  RedfishDiscover.h
+
+Abstract:
+
+  EFI Redfish Discover Protocol definition per UEFI 2.8 (Mantis 1920),
+  with revised definitions from UEFI 2.8C (Mantis 2172).
+
+--*/
+
+#ifndef _EFI_REDFISH_DISCOVER_PROTOCOL_FOR_TEST_H_
+#define _EFI_REDFISH_DISCOVER_PROTOCOL_FOR_TEST_H_
+
+#include <Protocol/RedfishDiscover.h>
+
+#endif


### PR DESCRIPTION
Summary
Add new black-box test module for EFI_REDFISH_DISCOVER_PROTOCOL covering all four protocol functions introduced in UEFI 2.8 (Mantis 1920), with clarifications from Mantis 1925 and revised definitions from UEFI 2.8C (Mantis 2172).

Function tests:

GetNetworkInterfaceList() — valid call and interface count consistency
AcquireRedfishService() — synchronous discovery via host interface
AbortAcquireRedfishService() — basic abort with NULL target
ReleaseRedfishService() — release with empty list
Conformance tests:

GetNetworkInterfaceList() with NULL NumberOfNetworkInterfaces, NULL NetworkInterfaces, and NULL ImageHandle
AcquireRedfishService() with NULL Token, Flags == 0, VALIDATION-only flags, and NULL ImageHandle
ReleaseRedfishService() with NULL List
Per Mantis 2172, the EFI_REDFISH_DISCOVER_VALIDATION flag is a modifier rather than a discovery method — setting it alone is treated as Flags == 0 and returns EFI_INVALID_PARAMETER.

Test plan

 Builds cleanly with GCC toolchain for X64 (requires fix-efi-h-tiano-pragma-once for Efi.h compat)

 Verify conformance tests pass on platform with Redfish Discover protocol installed

 Verify function tests produce WARNING (not FAIL) on platforms without a Redfish service
Ref: #323, #324