### PR TITLE
SctPkg: Update EFI_SYSTEM_TABLE version checks for UEFI 2.8+ (Mantis …

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestRequired_uefi.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Generic/EfiCompliant/BlackBoxTest/EfiCompliantBBTestRequired_uefi.c
@@ -259,7 +259,7 @@ CheckSystemTable (
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   } else {
     if ((gtST->Hdr.Signature       == EFI_SYSTEM_TABLE_SIGNATURE      ) &&
-        (gtST->Hdr.Revision        >= 0x00020000                      ) &&
+        (gtST->Hdr.Revision        >= EFI_2_00_SYSTEM_TABLE_REVISION  ) &&
         (gtST->Hdr.Reserved        == 0x00000000                      ) &&
         (gtST->RuntimeServices     != NULL                            ) &&
         (gtST->BootServices        != NULL                            ) &&
@@ -359,7 +359,7 @@ CheckBootServices (
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   } else {
     if ((gtBS->Hdr.Signature                       == EFI_BOOT_SERVICES_SIGNATURE) &&
-        (gtBS->Hdr.Revision                        >= 0x00020000                 ) &&
+        (gtBS->Hdr.Revision                        >= EFI_2_00_SYSTEM_TABLE_REVISION) &&
         (gtBS->Hdr.Reserved                        == 0x00000000                 ) &&
         (gtBS->RaiseTPL                            != NULL                       ) &&
         (gtBS->RestoreTPL                          != NULL                       ) &&
@@ -572,7 +572,7 @@ CheckBootServices (
   //
   // Check new boot service introduced by UEFI spec
   //
-  if (gtBS->Hdr.Revision >= 0x00020000) {
+  if (gtBS->Hdr.Revision >= EFI_2_00_SYSTEM_TABLE_REVISION) {
     StandardLib->RecordMessage (
                    StandardLib,
                    EFI_VERBOSE_LEVEL_DEFAULT,
@@ -616,7 +616,7 @@ CheckRuntimeServices (
     AssertionType = EFI_TEST_ASSERTION_FAILED;
   } else {
     if ((gtRT->Hdr.Signature             == EFI_RUNTIME_SERVICES_SIGNATURE) &&
-        (gtRT->Hdr.Revision              >= 0x00020000                    ) &&
+        (gtRT->Hdr.Revision              >= EFI_2_00_SYSTEM_TABLE_REVISION ) &&
         (gtRT->Hdr.Reserved              == 0x00000000                    ) &&
         (gtRT->GetTime                   != NULL                          ) &&
         (gtRT->SetTime                   != NULL                          ) &&
@@ -707,7 +707,7 @@ CheckRuntimeServices (
   //
   // Check new runtime service introduced by UEFI spec
   //
-  if (gtRT->Hdr.Revision >= 0x00020000) {
+  if (gtRT->Hdr.Revision >= EFI_2_00_SYSTEM_TABLE_REVISION) {
     StandardLib->RecordMessage (
                    StandardLib,
                    EFI_VERBOSE_LEVEL_DEFAULT,

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/Include/SctDef.h
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/Include/SctDef.h
@@ -49,6 +49,16 @@ Abstract:
 #define EFI_SCT_NAME                        L"UEFI2.6 Self Certification Test(SCT2)"
 #elif (EFI_SPECIFICATION_VERSION == EFI_2_70_SYSTEM_TABLE_REVISION)
 #define EFI_SCT_NAME                        L"UEFI2.7 Self Certification Test(SCT2)"
+#elif (EFI_SPECIFICATION_VERSION == EFI_2_80_SYSTEM_TABLE_REVISION)
+#define EFI_SCT_NAME                        L"UEFI2.8 Self Certification Test(SCT2)"
+#elif (EFI_SPECIFICATION_VERSION == EFI_2_90_SYSTEM_TABLE_REVISION)
+#define EFI_SCT_NAME                        L"UEFI2.9 Self Certification Test(SCT2)"
+#elif (EFI_SPECIFICATION_VERSION == EFI_2_100_SYSTEM_TABLE_REVISION)
+#define EFI_SCT_NAME                        L"UEFI2.10 Self Certification Test(SCT2)"
+#elif (EFI_SPECIFICATION_VERSION == EFI_2_110_SYSTEM_TABLE_REVISION)
+#define EFI_SCT_NAME                        L"UEFI2.11 Self Certification Test(SCT2)"
+#elif (EFI_SPECIFICATION_VERSION > EFI_2_110_SYSTEM_TABLE_REVISION)
+#define EFI_SCT_NAME                        L"UEFI Self Certification Test(SCT2)"
 #else
 #error Unknown EFI_SPECIFICATION_VERSION
 #endif

--- a/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/UI/MainMenu.c
+++ b/uefi-sct/SctPkg/TestInfrastructure/SCT/Framework/UI/MainMenu.c
@@ -275,7 +275,70 @@ Returns:
              (VOID *)(UINTN)EFI_MENU_ITEM_UTILITY,
              Page
              );
-#endif  
+#elif (EFI_SPECIFICATION_VERSION == 0x00020032)
+  Status = AddSimpleMenuItem (
+             EFI_ITEM_HAVE_SUBITEMS,
+             L"Help",
+             L"UEFI2.5 Self Certification Test is a toolkit to check an UEFI2.5 "
+             L"implementation is UEFI2.5 Specification compliant or not.",
+             (VOID *)(UINTN)EFI_MENU_ITEM_UTILITY,
+             Page
+             );
+#elif (EFI_SPECIFICATION_VERSION == 0x0002003C)
+  Status = AddSimpleMenuItem (
+             EFI_ITEM_HAVE_SUBITEMS,
+             L"Help",
+             L"UEFI2.6 Self Certification Test is a toolkit to check an UEFI2.6 "
+             L"implementation is UEFI2.6 Specification compliant or not.",
+             (VOID *)(UINTN)EFI_MENU_ITEM_UTILITY,
+             Page
+             );
+#elif (EFI_SPECIFICATION_VERSION == 0x00020046)
+  Status = AddSimpleMenuItem (
+             EFI_ITEM_HAVE_SUBITEMS,
+             L"Help",
+             L"UEFI2.7 Self Certification Test is a toolkit to check an UEFI2.7 "
+             L"implementation is UEFI2.7 Specification compliant or not.",
+             (VOID *)(UINTN)EFI_MENU_ITEM_UTILITY,
+             Page
+             );
+#elif (EFI_SPECIFICATION_VERSION == 0x00020050)
+  Status = AddSimpleMenuItem (
+             EFI_ITEM_HAVE_SUBITEMS,
+             L"Help",
+             L"UEFI2.8 Self Certification Test is a toolkit to check an UEFI2.8 "
+             L"implementation is UEFI2.8 Specification compliant or not.",
+             (VOID *)(UINTN)EFI_MENU_ITEM_UTILITY,
+             Page
+             );
+#elif (EFI_SPECIFICATION_VERSION == 0x0002005A)
+  Status = AddSimpleMenuItem (
+             EFI_ITEM_HAVE_SUBITEMS,
+             L"Help",
+             L"UEFI2.9 Self Certification Test is a toolkit to check an UEFI2.9 "
+             L"implementation is UEFI2.9 Specification compliant or not.",
+             (VOID *)(UINTN)EFI_MENU_ITEM_UTILITY,
+             Page
+             );
+#elif (EFI_SPECIFICATION_VERSION == 0x00020064)
+  Status = AddSimpleMenuItem (
+             EFI_ITEM_HAVE_SUBITEMS,
+             L"Help",
+             L"UEFI2.10 Self Certification Test is a toolkit to check an UEFI2.10 "
+             L"implementation is UEFI2.10 Specification compliant or not.",
+             (VOID *)(UINTN)EFI_MENU_ITEM_UTILITY,
+             Page
+             );
+#else
+  Status = AddSimpleMenuItem (
+             EFI_ITEM_HAVE_SUBITEMS,
+             L"Help",
+             L"UEFI Self Certification Test is a toolkit to check an UEFI "
+             L"implementation is UEFI Specification compliant or not.",
+             (VOID *)(UINTN)EFI_MENU_ITEM_UTILITY,
+             Page
+             );
+#endif
   if (EFI_ERROR(Status)) {
     DestroyMenuPage (Page);
     return Status;


### PR DESCRIPTION
…1926)

The SCT framework version definitions in SctDef.h only covered UEFI specifications through 2.7, causing a compile-time error when EFI_SPECIFICATION_VERSION was set to 2.8 or later. The MainMenu.c help strings were similarly limited, only reaching UEFI 2.4B. Additionally, EfiCompliantBBTestRequired_uefi.c used bare hex literals for revision comparisons instead of symbolic constants.

Changes:
- SctDef.h: Add EFI_SCT_NAME entries for UEFI 2.8, 2.9, 2.10, and 2.11; replace #error with forward-compatible #elif for versions beyond 2.11
- MainMenu.c: Add Help menu text for UEFI 2.5 through 2.10; add #else fallback with generic description for future spec versions
- EfiCompliantBBTestRequired_uefi.c: Replace 0x00020000 magic numbers with EFI_2_00_SYSTEM_TABLE_REVISION in system table, boot services, and runtime services revision checks

Ref: https://github.com/tianocore/edk2-test/issues/334