### PR TITLE
SctPkg/AtaPassThruBBTest: Accept dual GetNextDevice() behavior (Manti…

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AtaPassThru/BlackBoxTest/AtaPassThruBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AtaPassThru/BlackBoxTest/AtaPassThruBBTestConformance.c
@@ -923,19 +923,23 @@ BBTestGetNextDeviceConformanceAutoTest (
   //
   // Check Point1
   //
+  // Per UEFI 2.10A (Mantis 2359): when no port multiplier is connected,
+  // GetNextDevice() may return EFI_NOT_FOUND, making it impossible to
+  // derive an invalid PortMultiplierPort. Skip this checkpoint in that case.
+  //
   Status = GetInvalidPortMultiplierPort (AtaPassThru, Port, &InvalidPortMultiplierPort);
   if (EFI_ERROR(Status)) {
     StandardLib->RecordAssertion (
                    StandardLib,
-                   EFI_TEST_ASSERTION_FAILED,
+                   EFI_TEST_ASSERTION_WARNING,
                    gTestGenericFailureGuid,
-                   L"Get invalid PortMultiplierPort fail",
+                   L"Get invalid PortMultiplierPort - no devices enumerable, skipping checkpoint 1",
                    L"%a:%d:Status - %r\n",
                    __FILE__,
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    return EFI_SUCCESS;
   }
   
   Status = AtaPassThru->GetNextDevice (AtaPassThru, Port, &InvalidPortMultiplierPort);
@@ -962,19 +966,24 @@ BBTestGetNextDeviceConformanceAutoTest (
   //
   // Check Point2.
   //
+  // Per UEFI 2.10A (Mantis 2359): when no port multiplier is connected,
+  // GetNextDevice() may return EFI_NOT_FOUND instead of EFI_SUCCESS with
+  // PortMultiplierPort = 0xFFFF. Skip this checkpoint if no device is
+  // enumerable on this port.
+  //
   Status = AtaPassThru->GetNextDevice (AtaPassThru, Port, &PortMultiplierPort1);
   if (EFI_ERROR(Status)) {
     StandardLib->RecordAssertion (
                    StandardLib,
-                   EFI_TEST_ASSERTION_FAILED,
+                   EFI_TEST_ASSERTION_WARNING,
                    gTestGenericFailureGuid,
-                   L"Get 1st PortMultiplierPort fail",
+                   L"Get 1st PortMultiplierPort - no device enumerable, skipping checkpoint 2",
                    L"%a:%d:Status - %r\n",
                    __FILE__,
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    return EFI_SUCCESS;
   }
 
   PortMultiplierPort2 = PortMultiplierPort1;
@@ -983,15 +992,15 @@ BBTestGetNextDeviceConformanceAutoTest (
   if (EFI_ERROR(Status)) {
     StandardLib->RecordAssertion (
                    StandardLib,
-                   EFI_TEST_ASSERTION_FAILED,
+                   EFI_TEST_ASSERTION_WARNING,
                    gTestGenericFailureGuid,
-                   L"Get 2nd PortMultiplierPort fail",
+                   L"Get 2nd PortMultiplierPort - only one device on port, skipping checkpoint 2",
                    L"%a:%d:Status - %r\n",
                    __FILE__,
                    (UINTN)__LINE__,
                    Status
                    );
-    return Status;
+    return EFI_SUCCESS;
   }
 
   Status = AtaPassThru->GetNextDevice (AtaPassThru, Port, &PortMultiplierPort2);

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AtaPassThru/BlackBoxTest/AtaPassThruBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AtaPassThru/BlackBoxTest/AtaPassThruBBTestFunction.c
@@ -631,7 +631,14 @@ BBTestGetNextDeviceFunctionAutoTest (
         }
       }
 
+      //
+      // Per UEFI 2.10A (Mantis 2359): when no port multiplier is connected,
+      // GetNextDevice() may either return EFI_NOT_FOUND or return EFI_SUCCESS
+      // with PortMultiplierPort set to 0xFFFF.
+      //
       if (Status == EFI_NOT_FOUND) {
+        AssertionType = EFI_TEST_ASSERTION_PASSED;
+      } else if ((Status == EFI_SUCCESS) && (PortMultiplierPort == 0xFFFF)) {
         AssertionType = EFI_TEST_ASSERTION_PASSED;
       } else {
         AssertionType = EFI_TEST_ASSERTION_FAILED;
@@ -642,10 +649,11 @@ BBTestGetNextDeviceFunctionAutoTest (
                      AssertionType,
                      gAtaPassThruBBTestFunctionAssertionGuid006,
                      L"EFI_ATA_PASS_THRU_PROTOCOL.GetNextDevice - Invoke GetNextDevice() and verify interface correctness within test case",
-                     L"%a:%d:Status - %r",
+                     L"%a:%d:Status - %r, PortMultiplierPort - 0x%x",
                      __FILE__,
                      (UINTN)__LINE__,
-                     Status
+                     Status,
+                     PortMultiplierPort
                      );
     }
   } 


### PR DESCRIPTION
…s 2359)

UEFI 2.10A (Mantis 2359) updated EFI_ATA_PASS_THRU_PROTOCOL to clarify that when a port multiplier is not connected, GetNextDevice() may either return EFI_SUCCESS with PortMultiplierPort set to 0xFFFF, or return EFI_NOT_FOUND (in which case PortMultiplierPort is undefined).

The existing tests only accepted EFI_NOT_FOUND as a valid terminal condition, causing false failures on implementations that return EFI_SUCCESS + 0xFFFF.

Changes:
- AtaPassThruBBTestFunction.c: Update BBTestGetNextDeviceFunctionAutoTest to accept both EFI_NOT_FOUND and EFI_SUCCESS with PortMultiplierPort == 0xFFFF as passing conditions after device enumeration
- AtaPassThruBBTestConformance.c: Update BBTestGetNextDeviceConformance checkpoint 1 and 2 to gracefully skip (WARNING) instead of fail when GetNextDevice returns EFI_NOT_FOUND due to no port multiplier connected

Ref: https://github.com/tianocore/edk2-test/issues/341