### PR TITLE
SctPkg/Library/SctLib: Drop unused EfiDebugPrint

### DIFF
--- a/uefi-sct/SctPkg/Library/SctLib/Debug.c
+++ b/uefi-sct/SctPkg/Library/SctLib/Debug.c
@@ -36,58 +36,6 @@ Abstract:
 UINTN    EfiDebugMask    = EFI_DBUG_MASK;
 
 /**
-  Prints a debug message to the debug output device if the specified error level is enabled.
-
-  If Format is NULL, then ASSERT().
-
-  @param  ErrorLevel  The error level of the debug message.
-  @param  Format      The format string for the debug message to print.
-  @param  ...         The variable argument list whose contents are accessed
-                      based on the format string specified by Format.
-
-**/
-  VOID
-EfiDebugPrint (
-  IN  UINTN   ErrorLevel,
-  IN  CHAR8  *Format,
-  ...
-  )
-{
-  CHAR16   Buffer[MAX_DEBUG_MESSAGE_LENGTH];
-  VA_LIST  Marker;
-  CHAR16   *FormatUnicode;
-
-  //
-  // If Format is NULL, then ASSERT().
-  //
-  ASSERT (Format != NULL);
-
-  //
-  // Check driver debug mask value and global mask
-  //
-  if ((ErrorLevel & EfiDebugMask) == 0) {
-    return;
-}
-
-//
-  // Convert the DEBUG() message to a Unicode String
-//
-  VA_START (Marker, Format);
-  FormatUnicode = SctAllocatePool(SctAsciiStrSize (Format) * sizeof (CHAR16));
-  SctAsciiToUnicode (FormatUnicode, Format, SctAsciiStrSize (Format));
-  SctVSPrint (Buffer, MAX_DEBUG_MESSAGE_LENGTH, FormatUnicode, Marker);
-  VA_END (Marker);
-
-  //
-  // Send the print string to the Standard Error device
-  //
-  if ((tST != NULL) && (tST->StdErr != NULL)) {
-    tST->StdErr->OutputString (tST->StdErr, Buffer);
-  }
-}
-
-
-/**
   Prints an assert message containing a filename, line number, and description.
   This may be followed by a breakpoint or a dead loop.
 


### PR DESCRIPTION
EfiDebugPrint in SctLib/Debug.c appears to be an early attempt at a
SCT-local debug printer keyed on EfiDebugMask. It was never wired up:
the codebase instead uses the standard EDK2 DEBUG() macro, e.g.
DEBUG((EFI_D_ERROR, "...")), so this function has been an orphan
since the original UEFI SCT 2.3.1C draft import in 2013 (commit
https://github.com/tianocore/edk2-test/commit/50e74d0eecb049c118a595dd3a72b9d74420cebc).

The surrounding infrastructure (EfiDebugMask global, EfiDebugAssert,
EfiDebugVariable, EfiDebugAssertInit) is still in use by
SctLib/Print.c and stays in place. Only the orphan EfiDebugPrint
function is removed.