### PR TITLE
uefi-sct: Use GCC toolchain tag for modern edk2 builds

### DIFF
--- a/uefi-sct/SctPkg/build.sh
+++ b/uefi-sct/SctPkg/build.sh
@@ -193,7 +193,11 @@ case `uname` in
 		GCC* | gcc*)
 			set_cross_compile
 			CROSS_COMPILE="$TEMP_CROSS_COMPILE"
-			export TARGET_TOOLS=`get_gcc_version "$CROSS_COMPILE"gcc`
+
+			# Latest edk2 uses GCC as the GCC toolchain tag.
+			# old GCC5 and below versions are deprecated and are removed from
+			# tools_def.txt in edk2
+			export TARGET_TOOLS=GCC
 		;;
 
 		*)


### PR DESCRIPTION
Recent edk2 tool definitions use GCC as the GCC toolchain tag. The SCT build script currently maps a GCC command-line request to a versioned toolchain tag such as GCC5 by probing the compiler version.

This no longer works with modern edk2 configurations where GCC5 is not defined in tools_def.txt. Preserve the GCC toolchain tag when GCC is requested, while still setting the architecture-specific cross-compiler prefix as before.

This matches the modern edk2 toolchain model and avoids requiring local GCC5 compatibility aliases in edk2/Conf/tools_def.txt.

Refer to edk2 commit: https://github.com/tianocore/edk2/commit/bdadb269e379cb32281fb7434ebb8f8d1b9e0b60