### PR TITLE
SctPkg: typo maximumly

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/BlockIo2/BlackBoxTest/BlockIo2BBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/BlockIo2/BlackBoxTest/BlockIo2BBTestFunction.c
@@ -1526,7 +1526,7 @@ END_WAIT:
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -2164,7 +2164,7 @@ BBTestReadBlocksExFunctionAutoTestCheckpoint3(
     // Busy Waiting for BatchReadToken signal
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for Async Batch Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for Async Batch Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -2432,7 +2432,7 @@ END_WAIT:
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -2991,7 +2991,7 @@ END_WAIT:
       //
       // Busy waiting 120s on all the execute entity being moved to finished queue
       //  
-      SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+      SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
       Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
       IndexI = 0;
       
@@ -3818,7 +3818,7 @@ BBTestWriteBlocksExFunctionAutoTestCheckpoint3(
     // Busy Waiting BathWriteToken signal
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for Async Batch Write events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for Async Batch Write events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     
     IndexI = 0;
@@ -4215,7 +4215,7 @@ END_WAIT:
       //
       // Busy waiting 120s on all the execute entity being moved to finished queue
       //  
-      SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+      SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
       Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
       IndexI = 0;
       
@@ -4662,7 +4662,7 @@ BBTestFushBlocksExFunctionAutoTestCheckpoint1(
     //
     // Busy waiting for all the flush blocks event signaled
     //
-    SctPrint (L"Wait maximumly 60s for all Async Flush events signaled\n\n");
+    SctPrint (L"Wait maximally 60s for all Async Flush events signaled\n\n");
     
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     Time = 0;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Flush.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Flush.c
@@ -677,7 +677,7 @@ BBTestFlushDiskExFunctionAutoTestCheckpoint1(
       //
       // Busy waiting 60s on all the execute entity being moved to finished queue
       //  
-      SctPrint (L"Wait maximumly 60s for all Async Flush events signaled\n\n");
+      SctPrint (L"Wait maximally 60s for all Async Flush events signaled\n\n");
       Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
       Index = 0;
       
@@ -1257,7 +1257,7 @@ BBTestFlushDiskExFunctionAutoTestCheckpoint3(
     // Busy Waiting for BatchFlushToken signal
     // Busy waiting 60s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 60s for Async Batch Read events signaled\n\n");
+    SctPrint (L"Wait maximally 60s for Async Batch Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     Index = 0;
     

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Read.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Read.c
@@ -1042,7 +1042,7 @@ END_WAIT:
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -1917,7 +1917,7 @@ BBTestReadDiskExFunctionAutoTestCheckpoint3(
     // Busy Waiting for AsyncBatchReadToken signal
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for Async Batch Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for Async Batch Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -2311,7 +2311,7 @@ END_WAIT:
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Write.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Write.c
@@ -846,7 +846,7 @@ END_WAIT:
       //
       // Busy waiting 120s on all the execute entity being moved to finished queue
       //  
-      SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+      SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
       Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
       IndexI = 0;
       IndexI = 0;
@@ -1953,7 +1953,7 @@ BBTestWriteDiskExFunctionAutoTestCheckpoint3(
     // Busy Waiting BathWriteToken signal
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for Async Batch Write events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for Async Batch Write events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
      
     IndexI = 0;

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_FlushEx.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_FlushEx.c
@@ -550,7 +550,7 @@ BBTestFlushExBasicTestCheckpoint1 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
     
@@ -998,7 +998,7 @@ BBTestFlushExBasicTestCheckpoint3 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
     

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_OpenEx.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_OpenEx.c
@@ -1038,7 +1038,7 @@ BBTestOpenExBasicTestCheckpoint1_Test1_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -1407,7 +1407,7 @@ BBTestOpenExBasicTestCheckpoint1_Test2_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
         
@@ -2034,7 +2034,7 @@ BBTestOpenExBasicTestCheckpoint1_Test3_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -2549,7 +2549,7 @@ BBTestOpenExBasicTestCheckpoint1_Test4_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -3190,7 +3190,7 @@ BBTestOpenExBasicTestCheckpoint1_Test5_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -4292,7 +4292,7 @@ BBTestOpenExBasicTestCheckpoint2_Test1_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -5437,7 +5437,7 @@ BBTestOpenExBasicTestCheckpoint2_Test2_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -6634,7 +6634,7 @@ BBTestOpenExBasicTestCheckpoint2_Test3_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -7891,7 +7891,7 @@ BBTestOpenExBasicTestCheckpoint2_Test4_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -9347,7 +9347,7 @@ BBTestOpenExBasicTestCheckpoint2_Test5_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_ReadEx.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_ReadEx.c
@@ -608,7 +608,7 @@ BBTestReadExBasicTestCheckpoint1 (
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
       
@@ -1242,7 +1242,7 @@ BBTestReadExBasicTestCheckpoint3 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
     

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_WriteEx.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_WriteEx.c
@@ -604,7 +604,7 @@ BBTestWriteExBasicTestCheckpoint1 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
     
@@ -1352,7 +1352,7 @@ BBTestWriteExBasicTestCheckpoint3 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/BlockIo2/BlackBoxTest/BlockIo2BBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/BlockIo2/BlackBoxTest/BlockIo2BBTestFunction.c
@@ -1513,7 +1513,7 @@ END_WAIT:
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -2149,7 +2149,7 @@ BBTestReadBlocksExFunctionAutoTestCheckpoint3(
     // Busy Waiting for BatchReadToken signal
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for Async Batch Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for Async Batch Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -2416,7 +2416,7 @@ END_WAIT:
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -2973,7 +2973,7 @@ END_WAIT:
       //
       // Busy waiting 120s on all the execute entity being moved to finished queue
       //  
-      SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+      SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
       Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
       IndexI = 0;
       
@@ -3798,7 +3798,7 @@ BBTestWriteBlocksExFunctionAutoTestCheckpoint3(
     // Busy Waiting BathWriteToken signal
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for Async Batch Write events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for Async Batch Write events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     
     IndexI = 0;
@@ -4196,7 +4196,7 @@ END_WAIT:
       //
       // Busy waiting 120s on all the execute entity being moved to finished queue
       //  
-      SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+      SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
       Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
       IndexI = 0;
       
@@ -4641,7 +4641,7 @@ BBTestFushBlocksExFunctionAutoTestCheckpoint1(
     //
     // Busy waiting for all the flush blocks event signaled
     //
-    SctPrint (L"Wait maximumly 60s for all Async Flush events signaled\n\n");
+    SctPrint (L"Wait maximally 60s for all Async Flush events signaled\n\n");
     
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     Time = 0;

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Flush.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Flush.c
@@ -672,7 +672,7 @@ BBTestFlushDiskExFunctionAutoTestCheckpoint1(
       //
       // Busy waiting 60s on all the execute entity being moved to finished queue
       //  
-      SctPrint (L"Wait maximumly 60s for all Async Flush events signaled\n\n");
+      SctPrint (L"Wait maximally 60s for all Async Flush events signaled\n\n");
       Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
       Index = 0;
       
@@ -1250,7 +1250,7 @@ BBTestFlushDiskExFunctionAutoTestCheckpoint3(
     // Busy Waiting for BatchFlushToken signal
     // Busy waiting 60s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 60s for Async Batch Read events signaled\n\n");
+    SctPrint (L"Wait maximally 60s for Async Batch Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     Index = 0;
     

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Read.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Read.c
@@ -1035,7 +1035,7 @@ END_WAIT:
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -1908,7 +1908,7 @@ BBTestReadDiskExFunctionAutoTestCheckpoint3(
     // Busy Waiting for AsyncBatchReadToken signal
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for Async Batch Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for Async Batch Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     
@@ -2301,7 +2301,7 @@ END_WAIT:
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
     

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Write.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/DiskIo2/BlackBoxTest/DiskIo2BBTestFunction_Write.c
@@ -841,7 +841,7 @@ END_WAIT:
       //
       // Busy waiting 120s on all the execute entity being moved to finished queue
       //  
-      SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+      SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
       Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
       IndexI = 0;
       IndexI = 0;
@@ -1946,7 +1946,7 @@ BBTestWriteDiskExFunctionAutoTestCheckpoint3(
     // Busy Waiting BathWriteToken signal
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for Async Batch Write events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for Async Batch Write events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
      
     IndexI = 0;

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_FlushEx.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_FlushEx.c
@@ -544,7 +544,7 @@ BBTestFlushExBasicTestCheckpoint1 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
     
@@ -990,7 +990,7 @@ BBTestFlushExBasicTestCheckpoint3 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
     

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_OpenEx.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_OpenEx.c
@@ -1013,7 +1013,7 @@ BBTestOpenExBasicTestCheckpoint1_Test1_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -1380,7 +1380,7 @@ BBTestOpenExBasicTestCheckpoint1_Test2_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
         
@@ -2005,7 +2005,7 @@ BBTestOpenExBasicTestCheckpoint1_Test3_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -2518,7 +2518,7 @@ BBTestOpenExBasicTestCheckpoint1_Test4_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -3157,7 +3157,7 @@ BBTestOpenExBasicTestCheckpoint1_Test5_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -4256,7 +4256,7 @@ BBTestOpenExBasicTestCheckpoint2_Test1_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -5399,7 +5399,7 @@ BBTestOpenExBasicTestCheckpoint2_Test2_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -6594,7 +6594,7 @@ BBTestOpenExBasicTestCheckpoint2_Test3_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -7849,7 +7849,7 @@ BBTestOpenExBasicTestCheckpoint2_Test4_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       
@@ -9303,7 +9303,7 @@ BBTestOpenExBasicTestCheckpoint2_Test5_Async (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Open events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Open events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_ReadEx.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_ReadEx.c
@@ -602,7 +602,7 @@ BBTestReadExBasicTestCheckpoint1 (
     //
     // Busy waiting 120s on all the execute entity being moved to finished queue
     //  
-    SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+    SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
     Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
     IndexI = 0;
       
@@ -1234,7 +1234,7 @@ BBTestReadExBasicTestCheckpoint3 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Read events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Read events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
     

--- a/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_WriteEx.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/IHV/Protocol/SimpleFileSystem/BlackBoxTest/SimpleFileSystemExBBTestFunction_WriteEx.c
@@ -598,7 +598,7 @@ BBTestWriteExBasicTestCheckpoint1 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
     
@@ -1344,7 +1344,7 @@ BBTestWriteExBasicTestCheckpoint3 (
   //
   // Busy waiting 120s on all the execute entity being moved to finished queue
   //  
-  SctPrint (L"Wait maximumly 120s for all Async Write events signaled\n\n");
+  SctPrint (L"Wait maximally 120s for all Async Write events signaled\n\n");
   Status = gtBS->SetTimer (TimerEvent, TimerPeriodic, 10000000);
   IndexI = 0;
       


### PR DESCRIPTION
Replace all occurrences of maximumly by the correct adverb maximally.